### PR TITLE
Phase 0: maze-gen ↔ mazzzze region contract (region façade)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: Publish to NuGet
+
+# Publishes PlayersWorlds.Maps to nuget.org on a version tag (vX.Y.Z).
+# Create the tag with `make release-minor` / `-patch` / `-major`.
+#
+# Auth is NuGet Trusted Publishing (OIDC) — no stored API key. A trusted
+# publisher policy on nuget.org must be bound to THIS repo, the `publish.yml`
+# workflow, and the `production` environment; the account username is the
+# `NUGET_USER` repository variable.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write   # required for OIDC trusted publishing
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Derive and validate version from tag
+        # GITHUB_REF_NAME is the tag (vX.Y.Z). Validate it is real semver before
+        # it flows into build args (defense-in-depth against a malformed tag).
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "Tag '${GITHUB_REF_NAME}' is not a valid vX.Y.Z version." >&2
+            exit 1
+          fi
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Restore
+        run: dotnet restore maze-gen.sln
+
+      - name: Build
+        run: dotnet build maze-gen.sln -c Release --no-restore -p:Version="$VERSION"
+
+      - name: Test (gate the release)
+        run: dotnet test maze-gen.sln -c Release --no-build --filter "TestCategory!=Load & TestCategory!=Integration"
+
+      - name: Pack
+        run: dotnet pack src/PlayersWorlds.Maps.csproj -c Release --no-build -p:Version="$VERSION" -o artifacts
+
+      - name: NuGet login (OIDC trusted publishing)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ vars.NUGET_USER }}
+
+      - name: Push
+        run: >
+          dotnet nuget push "artifacts/*.nupkg"
+          --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate

--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,19 @@ clean: ## Remove build outputs
 
 .PHONY: ci
 ci: lint build test demo ## What CI runs: lint + build + unit tests + smoke render
+
+.PHONY: pack
+pack: ## Build the NuGet package locally -> build/nupkg (dev version 0.0.0)
+	dotnet pack src/PlayersWorlds.Maps.csproj -c Release -o build/nupkg
+
+.PHONY: release-patch
+release-patch: ## Tag a patch release (x.y.Z+1); CI publishes to NuGet
+	./tasks/release.sh patch
+
+.PHONY: release-minor
+release-minor: ## Tag a minor release (x.Y+1.0); CI publishes to NuGet
+	./tasks/release.sh minor
+
+.PHONY: release-major
+release-major: ## Tag a major release (X+1.0.0); CI publishes to NuGet
+	./tasks/release.sh major

--- a/README.md
+++ b/README.md
@@ -1,83 +1,74 @@
-# Summary
+# PlayersWorlds.Maps
 
-PlayersWorlds.Maps is a helper library that contains algorithms to help generate
-dungeon and maze maps for your 2D and 3D games.
+A procedural **maze / dungeon map-generation** library — corridors, rooms, halls,
+caves, and impassable zones for 2D/3D games. It generates the *backbone* of a map;
+the consuming game supplies gameplay, loot, mobs, and the visual layer.
 
-The basic workflow is:
+The core library is **BCL-only** (no third-party dependencies) and targets
+**net8.0**, so it drops cleanly into a Godot 4 project.
 
-1. Add the latest `PlayersWorlds.Maps.dll` to your Unity assets folder.
-2. Use the following code to generate the map:
+## Install
 
-   ```c#
-   Console.WriteLine(
-      new GeneratedWorld(RandomSource.CreateFromEnv())
-         .AddLayer(AreaType.Maze, new Vector(3, 2))
-         .OfMaze(MazeStructureStyle.Border, new GeneratorOptions() {
-                           MazeAlgorithm = GeneratorOptions.Algorithms.HuntAndKill,
-                           FillFactor = GeneratorOptions.MazeFillFactor.Full
-                        })
-         .ToMap(Maze2DRendererOptions.RectCells(3, 2))
-         .AddLayer(area => area.ShallowCopy(cells:
-            area.Select(cell =>
-               cell.Tags.Contains(Cell.CellTag.MazeTrail) ?
-                     new Cell(AreaType.Maze) :
-                     new Cell(AreaType.None))))
-         .OfMaze(MazeStructureStyle.Border, new GeneratorOptions() {
-                           MazeAlgorithm = GeneratorOptions.Algorithms.RecursiveBacktracker,
-                           FillFactor = GeneratorOptions.MazeFillFactor.ThreeQuarters
-                        })
-         .ToMap(Maze2DRendererOptions.RectCells(2, 1))
-         .Map()
-         .Render(new AsciiRendererFactory()));
-   ```
+```bash
+dotnet add package PlayersWorlds.Maps
+```
 
-3. This will generate a maze-like dungeon map that looks like the following:
+## Quick start — the region façade
 
-   ```
-   ▓▓▓▓▓▓▓▓▓▓▓▓▓▓          ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
-   ▓▓░░░░░░▓▓░░▓▓          ▓▓░░░░░░░░░░▓▓░░░░░░░░░░░░░░░░░░▓▓▓▓
-   ▓▓▓▓▒▒░░▒▒░░▓▓          ▓▓░░▒▒░░▒▒░░▒▒░░▒▒▓▓▓▓▓▓▓▓▓▓▒▒░░▒▒▓▓▓▓
-     ▓▓▓▓░░░░░░▓▓          ▓▓░░▓▓░░▓▓░░░░░░▓▓▓▓      ▓▓▓▓░░░░░░▓▓
-   ▓▓▓▓▓▓▓▓▒▒░░▓▓          ▓▓░░▓▓░░▒▒▓▓▓▓▓▓▓▓          ▓▓▓▓▒▒░░▓▓
-   ▓▓░░░░░░▓▓░░▓▓          ▓▓░░▓▓░░░░░░▓▓                ▓▓▓▓░░▓▓
-   ▓▓░░▒▒░░▒▒░░▓▓          ▓▓░░▒▒▓▓▒▒░░▓▓          ▓▓▓▓▓▓▓▓▒▒░░▓▓
-   ▓▓░░▓▓░░░░░░▓▓          ▓▓░░░░░░▓▓░░▓▓          ▓▓░░░░░░░░░░▓▓
-   ▓▓░░▒▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░▓▓          ▓▓▓▓▓▓▓▓▓▓▓▓▓▓
-   ▓▓░░░░░░░░░░▓▓░░░░░░░░░░▓▓░░░░░░▓▓░░▓▓
-   ▓▓▓▓▓▓▓▓▒▒░░▒▒░░▒▒▓▓▒▒░░▒▒░░▒▒░░▒▒░░▓▓
-         ▓▓▓▓░░░░░░▓▓▓▓▓▓░░░░░░▓▓░░░░░░▓▓
-           ▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
-   ```
+Games code against `PlayersWorlds.Maps.World`, a narrow, frozen contract over the
+generation pipeline (no internal `Area`/`Cell` types leak through):
 
-4. The resulting `map` is a [Area](https://aynurin.github.io/maze-gen/api/PlayersWorlds.Maps.Area.html)
-   instance that contains cells that map to Unity cells. To render the map you
-   iterate over the cells of the `map` and render whatever map objects you want
-   based on the cell tags, e.g. walls or floor tiles.
+```csharp
+using PlayersWorlds.Maps;
+using PlayersWorlds.Maps.World;
 
-5. The generated maze also contains markers for dead ends that can be a good
-   place to place loot, as well as the markers for the suggested starting and
-   ending cells that have a guaranteed and longest path between them.
+// Game start: one seeded world, created once.
+var world = new World(
+    store: new NullRegionStore(),      // supply your own IRegionStore to persist
+    worldSeed: 12345,
+    regionSize: new Vector(65, 65),    // the region's world footprint == RegionView.Size
+    defaultRecipe: RegionRecipe.Maze); // Maze / Corridors / Dungeon / Caverns
 
-# Contributing
+// As the player moves: generate (or load) a region, choosing its kind.
+RegionView region = world.GetOrCreate(new RegionAddress(new Vector(0, 0)));
 
-Check out the [contributing guide](CONTRIBUTING.md).
+foreach (var poi in region.Pois) { /* Entrance / Exit / DeadEnd, in local coords */ }
+bool floor = region.CellAt(new Vector(x, y)).IsPassable;  // drives your tiles
+```
 
-# Dev Environment
+Full integration guide, scenario coverage, and the latency envelope:
+**[`docs/INTEGRATION.md`](docs/INTEGRATION.md)**.
 
-1. Your favorite code editor. VSCode or Code OSS work well (I'm using Code OSS).
-   Please note that MonoDevelop (and perhaps Visual Studio) will change the
-   .csproj files putting a lot of unnecessary stuff there. If using one of those
-   IDEs, please don't send the .csproj files in your PRs to make sure the
-   project is maintainable in VSCode.
-2. This project is built for .NET Framework 4.7.2. Later versions of .NET are
-   not supported by Unity (yet?). I'm using the latest `mono` on Linux.
-3. All the Build/Test workflows are described in `./.vscode/tasks.json`, so if
-   using VSCode derived editor, you can use tasks to build, test, and get a
-   coverage report.
-4. Running the example maze-gen:
+The lower-level `GeneratedWorld` pipeline (layers, area overlays, explicit
+algorithm/render options) is still available for advanced composition — see
+[`docs/DESIGN.md`](docs/DESIGN.md).
 
-   ```bash
-   mono --debug build/Debug/mazegen/maze-gen.exe
-   ```
+## Build from source
 
-See some notes in the
+Requires the .NET SDK (net8.0). Everyday commands are in the **`Makefile`**:
+
+```bash
+make build     # dotnet build
+make test      # fast unit tests (what CI runs)
+make ci        # lint + build + test + smoke render
+make demo      # render a maze with two rooms as ASCII
+```
+
+To develop the library against a consuming game locally, reference it as a
+`ProjectReference` instead of the package — see the conditional-reference pattern
+in [`docs/INTEGRATION.md`](docs/INTEGRATION.md#consuming-the-library).
+
+## Docs
+
+- [`docs/PRD.md`](docs/PRD.md) — vision & journeys
+- [`docs/DESIGN.md`](docs/DESIGN.md) — architecture, API, algorithms
+- [`docs/INTEGRATION.md`](docs/INTEGRATION.md) — the living integration guide
+- [`docs/ROADMAP.md`](docs/ROADMAP.md) — phased plan
+
+## Contributing
+
+See the [contributing guide](CONTRIBUTING.md).
+
+## License
+
+[MIT](LICENSE).

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -87,6 +87,15 @@ RegionView caves  = world.GetOrCreate(new RegionAddress(new Vector(1, 0)),
         .WithCells(1));                              // square cells (the default)
 // Custom algorithm: RegionAlgorithm.Custom<MyGenerator>() (T : MazeGenerator).
 
+// Rooms: presets Dungeon (halls) and Caverns (caves), or add your own.
+// RoomKind.Hall / Cave (walkable) and Blocked (impassable rock/water). Sizes
+// are in world cells; "types" of room are open-ended tags, not an enum.
+RegionView dungeon = world.GetOrCreate(new RegionAddress(new Vector(2, 0)),
+    RegionRecipe.Maze
+        .WithRooms(6, minSize: new Vector(6, 6), maxSize: new Vector(10, 10),
+                   kind: RoomKind.Hall, tags: "armory")
+        .WithRooms(3, new Vector(4, 4), new Vector(6, 6), RoomKind.Blocked));
+
 // 3. Read cells by region-local (Block) coordinate. Passability drives tiles.
 for (var y = 0; y < region.Size.Y; y++) {
     for (var x = 0; x < region.Size.X; x++) {

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,0 +1,168 @@
+# Integrating PlayersWorlds.Maps
+
+**This is the single, living integration guide — it always reflects the *latest*
+state of the library, not a fixed version.** For each usage scenario in
+[`SCENARIOS.md`](./SCENARIOS.md) it says what you can integrate today and how,
+and stubs what is planned. It supersedes [`API-FIT.md`](./API-FIT.md) for
+forward-looking guidance (API-FIT is now a one-time gap snapshot kept as
+history).
+
+> **Upkeep is enforced, not remembered.** A change that alters public API or a
+> scenario's support status must update this file and the affected
+> `SCENARIOS.md` rows in the same change — an `openspec/config.yaml` rule
+> injects that obligation into every future change's instructions.
+
+Status legend: ✅ supported now · 🟡 partial · 🔴 planned (with the phase it
+lands in). Phases are defined in [`ROADMAP.md`](./ROADMAP.md).
+
+## The contract in one breath
+
+A game codes against one narrow, frozen surface — the **region façade**
+(`PlayersWorlds.Maps.World`) — never against `Area`/`Cell`. The engine
+generates a bounded **region** on request; the game owns persistence, streaming,
+and all mutations, keyed to the engine's stable identity.
+
+```mermaid
+flowchart LR
+  G["game (client or server)"] -->|GetOrCreate(address)| W["World façade"]
+  W -->|TryLoad| S["IRegionStore (game impl)"]
+  S -->|hit: blob| W
+  S -->|miss| GEN["generate region (per-address seed)"]
+  GEN -->|Save blob| S
+  W -->|RegionView| G
+```
+
+## Status at a glance
+
+| # | Scenario | Status | Notes / phase |
+|---|----------|--------|---------------|
+| **D1** | Generate & preview one map from a seed | ✅ | `GeneratedWorld` pipeline; `make demo` |
+| **D2** | Author a fixed layout | ✅ | `WithAreas(...)` typed child areas |
+| **D3** | Reproduce a specific map by seed | ✅ | `RandomSource.FromSeed`; deterministic |
+| **D4** | Compose layered / nested maps | ✅ | `AddLayer` + child-area overlays |
+| **D5** | Serialize & reload a map as a fixture | ✅ | `AreaSerializer` (lossless) — **not** `Serialize()`/`ToString()` |
+| **D6** | Tune area distribution for a target "feel" | 🟡 | Distribution tuning; Phase 3 |
+| **S1** | Generate a new region on first visit | ✅ | **Phase 0** — `World.GetOrCreate(address)` |
+| **S2** | Connect a region to neighbors (seam-stitching) | 🔴 | **Phase 2** — gate *shape* reserved (`RegionView.Gates`) |
+| **S3** | Persist a region and retrieve it later | ✅ | **Phase 0** — `IRegionStore` + lossless blob |
+| **S4** | Consistent world across instances via persistence | 🟡 | Follows from S1+S3 given a shared store; Phase 1 |
+| **S5** | Merge two independently-grown "countries" | 🔴 | Phase 2+ (post-v1 vision) |
+| **S6** | Extract gameplay metadata per region | 🟡 | POIs (entrance/exit/dead-ends) ✅; richer metadata later |
+| **S7** | Persist & share in-place mutations | 🔴 | Phase 1+ — engine owns identity, game owns state |
+| **C1** | Generate a region locally in real time | 🟡 | `GetOrCreate` is synchronous; game threads it (see envelope) |
+| **C2** | Consume a server-streamed region | ✅ | A `RegionView` (or its serialized blob) is the transport unit |
+| **C3** | Stream only the chunk(s) around the player | 🔴 | Phase 1 — region residency ring (mazzzze already rings chunks) |
+| **C4** | Render fog-of-war over the known map | 🟡 | Key to `(RegionAddress, localCell)` identity; game-side |
+| **C5** | Query connectivity / pathing for mobs & minimap | 🟡 | Passability per cell ✅; richer graph queries later |
+
+---
+
+## Phase-0 quickstart — the region façade
+
+Everything below is the **supported** integration path today.
+
+```csharp
+using PlayersWorlds.Maps;
+using PlayersWorlds.Maps.World;
+
+// 1. Make a world. NullRegionStore = regenerate each run, persist nothing.
+//    Supply your own IRegionStore to persist (see "Persistence" below).
+var world = new World(
+    store: new NullRegionStore(),
+    worldSeed: 12345,
+    regionMazeSize: new Vector(32, 32)); // in MAZE cells; Block size is larger
+
+// 2. Ask for the region at a lattice address. Synchronous: generate-once,
+//    then load. YOU decide when to call it and off which thread.
+RegionView region = world.GetOrCreate(new RegionAddress(new Vector(0, 0)));
+
+// 3. Read cells by region-local (Block) coordinate. Passability drives tiles.
+for (var y = 0; y < region.Size.Y; y++) {
+    for (var x = 0; x < region.Size.X; x++) {
+        RegionCell cell = region.CellAt(new Vector(x, y));
+        bool floor = cell.IsPassable;           // wall vs floor
+        // cell.Type, cell.Tags -> pick a tile / style
+    }
+}
+
+// 4. Points of interest come in region-local coordinates — place directly.
+Poi entrance = region.Pois.First(p => p.Kind == PoiKind.Entrance);
+Poi exit     = region.Pois.First(p => p.Kind == PoiKind.Exit);
+// PoiKind.DeadEnd -> loot / secrets / encounters
+
+// 5. Stable identity: (address, localCell). World coords are derived, so a
+//    region can unload/reload without re-keying anything.
+Vector worldCell = region.ToWorld(entrance.Local);
+```
+
+### S1 — Generate a new region on first visit ✅
+`World.GetOrCreate(address)` *is* this scenario: generate a correct, solvable,
+room-bearing region once, keyed to its address, deterministic for a given
+`worldSeed`. The engine never regenerates a region the store already has.
+
+### S3 — Persist a region and retrieve it later ✅
+Implement `IRegionStore` as a plain blob store — the engine owns the lossless
+`AreaSerializer` round-trip; you only persist/retrieve opaque strings:
+
+```csharp
+class MyStore : IRegionStore {
+    readonly IDictionary<string, string> _db; // your DB / files / KV
+    public bool TryLoad(RegionAddress a, out string blob) =>
+        _db.TryGetValue(Key(a), out blob);
+    public void Save(RegionAddress a, string blob) => _db[Key(a)] = blob;
+    static string Key(RegionAddress a) => a.ToString();
+}
+```
+
+On a store hit `GetOrCreate` reloads the exact region (cells + POIs survive as
+serialized tags); on a miss it generates, saves, and returns.
+
+### C-actor: consume / render / identity ✅🟡
+A `RegionView` (or its serialized blob) is the unit a server hands a client
+(**C2** ✅). Render straight from `CellAt(...).IsPassable` and cell tags. Fog
+of war (**C4**) and mob pathing/minimap (**C5**) key to the
+`(RegionAddress, localCell)` identity and per-cell passability; richer graph
+queries are a later phase.
+
+### Generation latency envelope (plan your threading — C1)
+Cold `GetOrCreate` (generate + Block render + serialize), Release build:
+
+| Region (maze) | Block size | Latency |
+|---|---|---|
+| 8×8 | 34×17 | ~55 ms |
+| 16×16 | 66×33 | ~110 ms |
+| 24×24 | 98×49 | ~160 ms |
+| 32×32 | 130×65 | ~320 ms |
+| 48×48 | 194×97 | ~930 ms |
+| 64×64 | 258×129 | ~2.2 s |
+
+Latency grows super-linearly with area. Rule of thumb: **≤16² is
+loading-screen-safe on the main thread; 32² and up should generate on a worker
+thread** ahead of the player's frontier.
+
+## Reference integration: mazzzze
+
+`mazzzze` (Godot 4 / net8.0) is the first reference consumer. Its map engine
+(`MazeData`) generates one region at startup via `GetOrCreate` on a
+`NullRegionStore`, and answers every map query — passability, chunk data,
+player spawn (entrance POI), and level goal (exit POI) — from the resident
+`RegionView`, keeping its chunk residency ring unchanged. See the
+`integrate-maze-gen-facade` branch of the mazzzze repo.
+
+---
+
+## Planned scenarios (stubs)
+
+These have no integration path yet; they land behind the **same** façade so v1
+calling code does not change shape.
+
+- **S2 — Seam-stitching** 🔴 *(Phase 2, core)* — generate a region whose border
+  gates line up with a neighbour's. The gate *shape* (`RegionView.Gates`) is
+  reserved now; gate-aware *generation* is Phase 2.
+- **S5 — Merge two grown regions** 🔴 *(Phase 2+)* — post-v1 vision.
+- **S7 — Persist & share mutations** 🔴 *(Phase 1+)* — the game stores
+  mutations keyed to the engine's `(address, cell)` identity; the engine never
+  owns mutable state.
+- **C3 — Stream chunks around the player** 🔴 *(Phase 1)* — a region residency
+  ring; mazzzze already rings chunks and will generalise to regions.
+- **D6 / S4 / S6 / C4 / C5 partials** 🟡 — advance incrementally; see the table.

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -67,10 +67,17 @@ using PlayersWorlds.Maps.World;
 
 // 1. Make a world. NullRegionStore = regenerate each run, persist nothing.
 //    Supply your own IRegionStore to persist (see "Persistence" below).
+//    Default cells are SQUARE 1x1 (the right shape for square game tiles).
 var world = new World(
     store: new NullRegionStore(),
     worldSeed: 12345,
-    regionMazeSize: new Vector(32, 32)); // in MAZE cells; Block size is larger
+    regionMazeSize: new Vector(32, 32)); // in MAZE cells; Block side = 2N+1
+
+// Cell shape is the CLIENT's setting: the default ctor is square; the
+// explicit ctor lets you widen corridors / walls (non-square stretches the
+// region, so only for deliberate effects):
+//   new World(store, seed, mazeSize, cellSize: new Vector(1,1),
+//                                    wallSize: new Vector(1,1));
 
 // 2. Ask for the region at a lattice address. Synchronous: generate-once,
 //    then load. YOU decide when to call it and off which thread.
@@ -125,16 +132,17 @@ of war (**C4**) and mob pathing/minimap (**C5**) key to the
 queries are a later phase.
 
 ### Generation latency envelope (plan your threading — C1)
-Cold `GetOrCreate` (generate + Block render + serialize), Release build:
+Cold `GetOrCreate` (generate + Block render + serialize), Release build, with the
+default **square** 1×1 cells (Block side = 2·maze + 1):
 
 | Region (maze) | Block size | Latency |
 |---|---|---|
-| 8×8 | 34×17 | ~55 ms |
-| 16×16 | 66×33 | ~110 ms |
-| 24×24 | 98×49 | ~160 ms |
-| 32×32 | 130×65 | ~320 ms |
-| 48×48 | 194×97 | ~930 ms |
-| 64×64 | 258×129 | ~2.2 s |
+| 8×8 | 17×17 | ~27 ms |
+| 16×16 | 33×33 | ~87 ms |
+| 24×24 | 49×49 | ~108 ms |
+| 32×32 | 65×65 | ~215 ms |
+| 48×48 | 97×97 | ~690 ms |
+| 64×64 | 129×129 | ~1.7 s |
 
 Latency grows super-linearly with area. Rule of thumb: **≤16² is
 loading-screen-safe on the main thread; 32² and up should generate on a worker

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -65,23 +65,27 @@ Everything below is the **supported** integration path today.
 using PlayersWorlds.Maps;
 using PlayersWorlds.Maps.World;
 
-// 1. Make a world. NullRegionStore = regenerate each run, persist nothing.
-//    Supply your own IRegionStore to persist (see "Persistence" below).
-//    Default cells are SQUARE 1x1 (the right shape for square game tiles).
+// 1. GAME START — make the world once. It holds what every region inherits:
+//    seed, store, region footprint, and a default recipe. NullRegionStore =
+//    regenerate each run, persist nothing (supply your own to persist).
 var world = new World(
     store: new NullRegionStore(),
     worldSeed: 12345,
-    regionMazeSize: new Vector(32, 32)); // in MAZE cells; Block side = 2N+1
+    regionSize: new Vector(65, 65),     // the region's WORLD footprint (Block
+                                        // cells) == RegionView.Size, exactly.
+    defaultRecipe: RegionRecipe.Maze);  // inherited unless a call overrides it
 
-// Cell shape is the CLIENT's setting: the default ctor is square; the
-// explicit ctor lets you widen corridors / walls (non-square stretches the
-// region, so only for deliberate effects):
-//   new World(store, seed, mazeSize, cellSize: new Vector(1,1),
-//                                    wallSize: new Vector(1,1));
-
-// 2. Ask for the region at a lattice address. Synchronous: generate-once,
-//    then load. YOU decide when to call it and off which thread.
+// 2. PLAYER POSITIONING / LOADING — ask for the region at an address, and let
+//    THIS region pick its kind. Synchronous: generate-once, then load. You
+//    decide when to call it and off which thread. A region's kind binds at
+//    first creation (a later call with a different recipe returns the stored
+//    region unchanged).
 RegionView region = world.GetOrCreate(new RegionAddress(new Vector(0, 0)));
+RegionView caves  = world.GetOrCreate(new RegionAddress(new Vector(1, 0)),
+    RegionRecipe.Corridors                       // intent preset...
+        .WithAlgorithm(RegionAlgorithm.HuntAndKill)  // ...or a specific algorithm
+        .WithCells(1));                              // square cells (the default)
+// Custom algorithm: RegionAlgorithm.Custom<MyGenerator>() (T : MazeGenerator).
 
 // 3. Read cells by region-local (Block) coordinate. Passability drives tiles.
 for (var y = 0; y < region.Size.Y; y++) {

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -15,6 +15,36 @@ history).
 Status legend: ✅ supported now · 🟡 partial · 🔴 planned (with the phase it
 lands in). Phases are defined in [`ROADMAP.md`](./ROADMAP.md).
 
+## Consuming the library
+
+The library ships to **nuget.org** as `PlayersWorlds.Maps` (BCL-only — no
+transitive dependencies to fight the Godot runtime):
+
+```bash
+dotnet add package PlayersWorlds.Maps
+```
+
+Other devs and CI just `dotnet build` — nothing to clone. If you also work on the
+library itself, use a **conditional reference** so a local source checkout wins
+automatically and everyone else falls back to the package:
+
+```xml
+<PropertyGroup>
+  <!-- true when the maze-gen checkout sits beside this repo; override with
+       -p:MazeGenLocal=false to force the published package. -->
+  <MazeGenLocal Condition="'$(MazeGenLocal)' == '' And Exists('../../krmrn42/maze-gen/src/PlayersWorlds.Maps.csproj')">true</MazeGenLocal>
+</PropertyGroup>
+<ItemGroup Condition="'$(MazeGenLocal)' == 'true'">
+  <ProjectReference Include="../../krmrn42/maze-gen/src/PlayersWorlds.Maps.csproj" />
+</ItemGroup>
+<ItemGroup Condition="'$(MazeGenLocal)' != 'true'">
+  <PackageReference Include="PlayersWorlds.Maps" Version="0.1.*" />
+</ItemGroup>
+```
+
+Releases are cut with `make release-minor` (or `-patch`/`-major`), which tags
+`vX.Y.Z`; CI publishes that version to NuGet via OIDC trusted publishing.
+
 ## The contract in one breath
 
 A game codes against one narrow, frozen surface — the **region façade**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,11 +38,13 @@ flowchart LR
 
 ## 3. Phases
 
-### Phase 0 — Design the engine contract *(design only)*
-**Goal:** define the interface `mazzzze` (and any consumer) codes against, built to outlast the MMO evolution. **Exit criteria:** an approved contract spec covering §6 below. **No integration yet.**
+### Phase 0 — Define the engine contract  ✅ *(defined & frozen)*
+**Goal:** define the interface `mazzzze` (and any consumer) codes against, built to outlast the MMO evolution. **Exit criteria:** an approved contract spec covering §6 below.
+**Done** in OpenSpec change `maze-gen-mazzzze-phase0-contract`. The contract is the **frozen façade surface** `PlayersWorlds.Maps.World`: `World.GetOrCreate(RegionAddress) → RegionView` (Block cells + POIs + gates + stable identity), the `IRegionStore` seam, and the value types `RegionAddress`/`RegionCell`/`Poi`/`Gate`. This is the freeze point — **Phases 1–3 add capability *behind* this surface without changing the calls v1 makes.** Integration guidance is the living [`INTEGRATION.md`](INTEGRATION.md).
 
-### Phase 1 — Referenceable + first integration *(earliest end-to-end)*
+### Phase 1 — Referenceable + first integration *(earliest end-to-end)*  🚧
 **Goal:** `mazzzze` renders a *real* library maze instead of its `IsFloor` hash.
+> **Largely landed with Phase 0** in the same change: the single-region façade + renderable cell data + entrance/exit/dead-end POIs are implemented, the D5 (`Serialize()`) and S6 (longest-path mis-tag) traps are fixed, and `mazzzze`'s `MazeData` is rewired onto the façade (branch `integrate-maze-gen-facade`, compiles). **Remaining:** P5 multi-target/packaging (currently a sibling `ProjectReference`) and the in-editor smoke-run (player walks the region in Godot).
 - **P5** — multi-target the core library `net472;net8.0` so Godot 4 can reference the DLL (the first domino; core already proven to compile on modern .NET).
 - Implement the **minimum** of the contract: generate a single region + return renderable cell data + entrance/exit/dead-end metadata.
 - Integrate: replace `MazeData.IsFloor` with a call into the library behind the contract; `mazzzze`'s existing `ChunkManager` samples the region into its `GridMap` chunks.
@@ -148,7 +150,8 @@ The single interface `mazzzze` codes against, designed to leave room for later p
 ---
 
 ## References
+- **[`docs/INTEGRATION.md`](INTEGRATION.md) — the canonical living integration guide** (always-latest; how to integrate the current API against every `SCENARIOS.md` scenario). Supersedes `API-FIT.md` for forward-looking guidance.
 - PR #40: `https://github.com/krmrn42/maze-gen/pull/40`
-- Docs: `docs/{PRD,DESIGN,COMPONENT-REVIEW,SCENARIOS,API-FIT,ROADMAP}.md`, `CLAUDE.md`
+- Docs: `docs/{PRD,DESIGN,COMPONENT-REVIEW,SCENARIOS,API-FIT,INTEGRATION,ROADMAP}.md`, `CLAUDE.md`
 - Game: `/home/data/repos/github.com/vasiliy-kiryukhin/mazzzze` (Godot 4, net8.0)
 - Validation harness (scratchpad, not committed): net10 probe referencing `src` as `PlayersWorlds.Maps.dll`

--- a/docs/SCENARIOS.md
+++ b/docs/SCENARIOS.md
@@ -62,12 +62,12 @@ The three actors:
 
 ## Actor 2 — Game server (authoritative, persistent, on demand)
 
-### S1 — Generate a new region on first visit  🔴
+### S1 — Generate a new region on first visit  ✅
 
 **Trigger:** A player reaches an un-generated region at coordinate `(X, Y)`.
 **Wants:** Generate a fresh region *once*, with its own seed, and hand it back to be **persisted** under that coordinate address; every later visitor loads the stored copy. The map is authored-by-generation and stored — **not** a deterministic function of coordinates.
-**Interaction (today):** the pipeline generates an `Area`, but there is no coordinate-addressed region factory and no persistence hook.
-**Support:** 🔴 — see [API-FIT: S1](API-FIT.md#s1).
+**Interaction:** `World.GetOrCreate(RegionAddress)` (Phase 0) generates a region once with a per-address seed, saves it via the game's `IRegionStore`, and returns a `RegionView`; a later visit loads the stored copy.
+**Support:** ✅ — Phase 0 region façade — see [INTEGRATION: S1](INTEGRATION.md#s1--generate-a-new-region-on-first-visit-).
 
 ### S2 — Connect a new region to its existing neighbors (seam-stitching)  🔴  *(core)*
 
@@ -76,12 +76,12 @@ The three actors:
 **Interaction (today):** fixed-position `Area.Create` areas and the distributor's "don't disturb fixed areas" rule are primitives, but there is no seam/border-connection API.
 **Support:** 🔴 — the load-bearing MMO capability — see [API-FIT: S2](API-FIT.md#s2).
 
-### S3 — Persist a region and retrieve it later  🟡
+### S3 — Persist a region and retrieve it later  ✅
 
 **Trigger:** A region was generated (visited) and must be stored centrally and re-served.
 **Wants:** Save a region under a key and load it back on demand.
-**Interaction:** `AreaSerializer` gives lossless text; there is no store, region keying, or partial-load layer.
-**Support:** 🟡 — serialization exists, persistence does not — see [API-FIT: S3](API-FIT.md#s3).
+**Interaction:** The `IRegionStore` seam (Phase 0) keys regions by `RegionAddress`; the engine serializes/deserializes losslessly via `AreaSerializer`, so the game implements a plain blob store. On a hit `GetOrCreate` reloads the stored region (cells + POIs survive as serialized tags).
+**Support:** ✅ — Phase 0 persistence seam — see [INTEGRATION: S3](INTEGRATION.md#s3--persist-a-region-and-retrieve-it-later-). Partial-load / streaming remains later-phase.
 
 ### S4 — Consistent world across instances via persistence  🟡
 

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/.openspec.yaml
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/design.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/design.md
@@ -79,3 +79,14 @@ Correct POIs require fixing `DijkstraDistance.FindLongestTrail` marker mis-taggi
 - Exact `Gate` representation (border edge + open-cell list vs. richer descriptor) — reserve now, refine with the Phase-2 stitch (P3) design.
 - Whether mazzzze v1 should opt into persistence (a real `IRegionStore`) or stay regenerate-at-startup — v1 default is regenerate; persistence is a free later opt-in behind the seam.
 - Region size / dimensionality defaults for mazzzze's single region — gameplay-driven, not a contract concern; `RegionAddress`/`Vector` stays N-D-ready.
+
+## As-built freeze (Phase 0)
+
+The **frozen façade surface** is `PlayersWorlds.Maps.World` (`src/world/`): `World.GetOrCreate(RegionAddress) → RegionView`; value types `RegionAddress`, `RegionCell`, `Poi`/`PoiKind`, `Gate`; the `IRegionStore` seam + `NullRegionStore`. Phases 1–3 add capability *behind* this surface without changing v1's calls.
+
+Refinements the implementation made over the proposal (all validated by grounding a real Block region):
+- **Passability lives in tags, not links.** Block cells carry no links, so `RegionCell` is `{ IsPassable (from the trail tag), Type, Tags }` — the proposal's `links`/`markers` fields were dropped as vestigial.
+- **POIs are baked as serializable cell tags.** `ToMap` discards the Border-maze POI markers, so the factory captures POIs pre-`ToMap` and bridges Border→Block coordinates via `CellsMapping.CenterPosition`, then tags the Block cells (`REGION_ENTRANCE/EXIT/DEADEND`). `RegionView` derives POIs from those tags, so a region is self-describing and its POIs survive persistence with no side-channel.
+- **`IRegionStore` is a blob store.** It persists opaque serialized strings keyed by address; the engine owns the lossless `AreaSerializer` round-trip (not `RegionView` objects). Cleaner for a game's KV/blob store.
+- **Per-address determinism** via a new public `RandomSource.FromSeed(int)`; each region's seed derives from `(worldSeed, address)`.
+- **Per-cell room type flattens to `Environment`** in current Block output; room/cave/corridor typing per cell is deferred behind the same `RegionCell.Type` field.

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/design.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/design.md
@@ -98,10 +98,10 @@ The generator was baked (`RecursiveBacktracker`, `Full`). It is now a client set
 
 Each configuration axis gets the openness that fits it — the crux of "simple *and* flexible":
 - **Algorithm** — finite blessed set, occasionally extended → **`RegionAlgorithm`**: discoverable static built-ins (the six generators) plus a `Custom<T>() where T : MazeGenerator` escape hatch. `MazeGenerator` is the engine's intended SPI, so `Custom` leaks nothing internal; the contract test still forbids renderer types.
-- **Room structure** (Phase 0.2) — small & stable → a closed `RoomKind` enum.
+- **Room structure** — small & stable → a closed `RoomKind` enum (`Hall`, `Cave`, `Blocked` = maze `Hall`/`Cave`/`Fill`, every room-capable area type).
 - **Room semantics** — unbounded, grows forever → open **string tags**, never an enum.
 
-Presets encode algorithm affinity so a caller names intent, not mechanism; because algorithms are interchangeable, any preset accepts `.WithAlgorithm(...)`. *Room support (`Dungeon`/`Caverns` presets + `WithRooms`) is deferred to a follow-up slice, added behind this same `RegionRecipe` type non-breakingly.*
+Presets encode algorithm affinity so a caller names intent, not mechanism; because algorithms are interchangeable, any preset accepts `.WithAlgorithm(...)`. Rooms are auto-placed via `WithRooms(count, min, max, kind, tags)` (sizes in world cells, snapped to the maze grid); presets `Dungeon` (halls) and `Caverns` (caves) build on it. This surfaced and fixed a core bug — `BasicAreaGenerator` crashed when no tags were supplied (`RandomOf` on an empty list). *Deferred to the next slice: **room metadata on `RegionView`** (where each room is + its kind/tags), which needs rooms baked into the serializable Block area so a reloaded region stays self-describing — the same pattern POIs use. Explicit `AddRoom(position, …)` placement is also deferred. Rooms currently affect geometry (walkable halls/caves, impassable blocks); a game reads them as passability today.*
 
 ## D10 — World vs region lifecycle; `regionSize` is the world footprint
 

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/design.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/design.md
@@ -90,3 +90,4 @@ Refinements the implementation made over the proposal (all validated by groundin
 - **`IRegionStore` is a blob store.** It persists opaque serialized strings keyed by address; the engine owns the lossless `AreaSerializer` round-trip (not `RegionView` objects). Cleaner for a game's KV/blob store.
 - **Per-address determinism** via a new public `RandomSource.FromSeed(int)`; each region's seed derives from `(worldSeed, address)`.
 - **Per-cell room type flattens to `Environment`** in current Block output; room/cave/corridor typing per cell is deferred behind the same `RegionCell.Type` field.
+- **Cell shape is square by default and client-owned.** The façade does not expose `Maze2DRendererOptions` (a renderer type — the contract test forbids it); instead `World` has a simple square-1×1 ctor and an explicit `(cellSize, wallSize)` ctor. The old `RectCells(2, 1)` default was an ASCII-console aspect ratio that wrongly stretched a game's square tiles 2:1 — removed.

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/design.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/design.md
@@ -90,4 +90,25 @@ Refinements the implementation made over the proposal (all validated by groundin
 - **`IRegionStore` is a blob store.** It persists opaque serialized strings keyed by address; the engine owns the lossless `AreaSerializer` round-trip (not `RegionView` objects). Cleaner for a game's KV/blob store.
 - **Per-address determinism** via a new public `RandomSource.FromSeed(int)`; each region's seed derives from `(worldSeed, address)`.
 - **Per-cell room type flattens to `Environment`** in current Block output; room/cave/corridor typing per cell is deferred behind the same `RegionCell.Type` field.
-- **Cell shape is square by default and client-owned.** The façade does not expose `Maze2DRendererOptions` (a renderer type — the contract test forbids it); instead `World` has a simple square-1×1 ctor and an explicit `(cellSize, wallSize)` ctor. The old `RectCells(2, 1)` default was an ASCII-console aspect ratio that wrongly stretched a game's square tiles 2:1 — removed.
+- **Cell shape is square by default and client-owned.** The façade does not expose `Maze2DRendererOptions` (a renderer type — the contract test forbids it); instead cell shape lives in the recipe (see D9). The old `RectCells(2, 1)` default was an ASCII-console aspect ratio that wrongly stretched a game's square tiles 2:1 — removed.
+
+## D9 — Configuration surface: recipe + algorithm, with the right openness per axis
+
+The generator was baked (`RecursiveBacktracker`, `Full`). It is now a client setting via a **`RegionRecipe`** — an immutable object with intent presets (`Maze`, `Corridors`) and fluent `With…` overrides (`WithAlgorithm`, `WithFill`, `WithCells`). This collapses what would be a constructor-parameter explosion into one configurable value, and keeps the simple path one call (recipe defaults to `Maze`).
+
+Each configuration axis gets the openness that fits it — the crux of "simple *and* flexible":
+- **Algorithm** — finite blessed set, occasionally extended → **`RegionAlgorithm`**: discoverable static built-ins (the six generators) plus a `Custom<T>() where T : MazeGenerator` escape hatch. `MazeGenerator` is the engine's intended SPI, so `Custom` leaks nothing internal; the contract test still forbids renderer types.
+- **Room structure** (Phase 0.2) — small & stable → a closed `RoomKind` enum.
+- **Room semantics** — unbounded, grows forever → open **string tags**, never an enum.
+
+Presets encode algorithm affinity so a caller names intent, not mechanism; because algorithms are interchangeable, any preset accepts `.WithAlgorithm(...)`. *Room support (`Dungeon`/`Caverns` presets + `WithRooms`) is deferred to a follow-up slice, added behind this same `RegionRecipe` type non-breakingly.*
+
+## D10 — World vs region lifecycle; `regionSize` is the world footprint
+
+Two lifecycle events, two homes for parameters:
+- **`new World(...)` — game start.** Holds what every region shares and inherits: seed, store, `regionSize`, and the default recipe.
+- **`GetOrCreate(address, recipe?)` — player positioning / environment loading.** The recipe/type is chosen *per region*, defaulting to the world's. A region's kind **binds at first generation**; a later call with a different recipe returns the stored region unchanged (mutations are out of scope, Phase 1+).
+
+`regionSize` is the region's **footprint in the world**, in Block cells — the uniform lattice pitch, and **exactly what `RegionView.Size` reports** (generation renders into a footprint-sized canvas; the maze-cell count is derived internally, and any remainder past the maze is impassable). This removes the old `regionMazeSize`→`Size` (N→2N+1) confusion: you ask for a 65×65 region, you get 65×65.
+
+**Uniform lattice** is the model: equal-size regions, `ToWorld = address·regionSize + local`. A gate-graph with uniform nodes and aligned gates *is* this lattice — the two are not in tension. Variable-size regions / non-Cartesian gate-adjacency are a Phase-2 generalization behind the same `GetOrCreate(address)`; the real Phase-2 work is seam-stitching (aligning a new region's gate to its neighbour), not a topology change.

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/design.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/design.md
@@ -1,0 +1,81 @@
+## Context
+
+`PlayersWorlds.Maps` (maze-gen) is a BCL-only .NET 8 maze/dungeon generation library. Its public entry point is the fluent `GeneratedWorld` pipeline, which produces an `Area` — a rich internal model (flat `List<Cell>`, child-area tree, `ExtensibleObject` attachments, split HardLinks/BakedLinks, Border-vs-Block styles). `mazzzze` (sibling Godot 4 / net8.0 MMO) currently ignores the library and builds its map from a coordinate hash (`MazeData.IsFloor`) on a fixed 10000×10000 grid.
+
+The [PRD vision](../../../docs/PRD.md#1-vision) is an **endless, generate-once-persist-share, independently-generated-then-stitched** world. The [ROADMAP](../../../docs/ROADMAP.md) settled the world model and the "contract-first, capability-progressive" principle. This change is **Phase 0**: design the one library contract a Godot game codes against, freeze it at first integration, and prove it by rewriting `mazzzze`'s map engine to consume it for a single real region.
+
+The vision's §1.2 responsibility boundary *is* the contract: every arrow crossing the **engine ↔ game** boundary is a protocol method; everything inside the game box (persist, stream, evict, transfer the player, mutate) the protocol must *enable*, never *do*.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A curated **façade** that exposes the vision's protocol as a narrow, freezable waist over the existing pipeline, leaking no `Area` internals.
+- Give a region the two things a maze-gen `Area` lacks today: a **place** (coordinate address) and **gates** (border openings — the future seam anchors), with the gate *shape* reserved now.
+- Correct, first-class **POIs** (entrance/exit + dead-ends) — which requires fixing the longest-path mis-tag.
+- A synchronous `GetOrCreate(address) → RegionView` factory and an `IRegionStore` persistence seam the game implements.
+- Rewrite `mazzzze`'s map engine to generate and render **one** real region, replacing the `IsFloor` hash — the first reference integration that validates the contract.
+
+**Non-Goals (deferred behind the frozen contract):**
+- Seam-**stitching** generation (Phase 2) — only the gate *shape* is reserved.
+- Persistence store implementation, multi-region worlds, streaming/eviction, player hand-off across seams — all **game-side** and later-phase.
+- Async/threaded generation *in the contract* — the call is synchronous; the game threads it.
+- Elevation/3D, environment tagging, distribution tuning (Phase 3).
+
+## Decisions
+
+### D1 — Façade as a new namespace in `src` (one DLL), not raw `Area`, not a separate assembly
+The game codes against new façade types (`RegionView`, `RegionCell`, POIs, gates, `IRegionStore`), **never** `Area`. Rationale: `Area` exposes internals that would couple Godot to the pipeline and prevent the contract from freezing. Keep the façade in `PlayersWorlds.Maps` (a `…World`/`…Contract` namespace) so Godot references **one** DLL; core stays BCL-only. *Alternative — separate façade assembly:* rejected for now (extra DLL, packaging overhead, marginal isolation). Extractable later without breaking consumers, since they only touch façade types.
+
+### D2 — `RegionView` wraps a baked **Block** region; cells carry a typed payload
+The façade emits **Block** cells (walls occupy their own cells) because a `GridMap`-style renderer is inherently block-based and tags exist only after Block conversion (`ToMap`). `RegionCell` exposes: passability (wall vs floor), `AreaType` (maze/hall/cave/fill/environment), block tags, links, and markers. No `Cell`/`Area` object escapes; `RegionView` returns read-only value data. *Alternative — expose Border + let game convert:* rejected (pushes internal knowledge to every consumer).
+
+### D3 — Address + identity is region-relative; world coords are derived
+`RegionAddress` is a `Vector` (N-D-ready) naming a region's place on the region lattice. Stable identity is `(RegionAddress, localCell)`; `ToWorld(address, size, local)` / `FromWorld(world, size)` derive absolute coords for the game's convenience. Fog-of-war and mutations key to the **relative** identity so a region can unload/reload transparently — the endless-world requirement. The fixed 10000² grid dies; the address space is unbounded.
+
+### D4 — Gates are metadata surfaced now; gate-aware *generation* is deferred
+`Gate` = a region border edge + the open cells along it. `RegionView.Gates` is part of the contract from day 1 (its shape is the one thing that forces a contract break if wrong). Phase 0 **surfaces** gates a region has; Phase 2 **consumes** a neighbor's gates as pre-carved stitch constraints (P3). This is the "entrance = minimap marker AND seam anchor, design once" unification.
+
+### D5 — `GetOrCreate` is synchronous; the store seam owns generate-once
+```mermaid
+flowchart LR
+  G["game (client or server)"] -->|GetOrCreate(address)| W["World façade"]
+  W -->|TryLoad| S["IRegionStore (game impl)"]
+  S -->|hit| RV["RegionView"]
+  S -->|miss| GEN["generate region (own seed)<br/>+ stitch neighbors (Phase 2)"]
+  GEN -->|Save| S
+  GEN --> RV
+```
+The call blocks (maze gen is bounded but can be slow — ~174 ms cold for 32²); the **game** decides when to call it and off which thread (e.g. ahead of a frontier, on a worker). There is no "endless" call — each call generates one bounded region; the endless world emerges from the game calling repeatedly. mazzzze v1 passes a `NullRegionStore` (always-miss, never-save) → regenerate at startup.
+
+### D6 — Documented maze-gen behavior changes: fix S6 and route persistence through `AreaSerializer`
+Correct POIs require fixing `DijkstraDistance.FindLongestTrail` marker mis-tagging (end marker on start cell; trail mis-tagged). The `IRegionStore` round-trip MUST use the lossless `AreaSerializer.Serialize/Deserialize`, **not** `GeneratedWorld.Serialize()`/`Area.ToString()` (debug labels that do not round-trip — the D5 trap). Both are shipped with runnable examples documenting the changed behavior.
+
+### D7 — mazzzze integration keeps chunk residency; swaps only the map *source*
+`mazzzze`'s `ChunkManager` keeps its load/unload ring; `Chunk` keeps writing to `GridMap`. Only the **source** changes: a new map-engine node calls `GetOrCreate` once at startup, holds the `RegionView`, and chunks *sample the resident region* instead of calling the `IsFloor` hash. Spawn/goal come from POIs. This is the minimal disruption that still validates every load-bearing part of the contract, and it leaves the residency machinery that the endless version will later generalize to regions.
+
+### D8 — Living integration guide as a doc; maintenance enforced by a config rule, not prose
+`docs/INTEGRATION.md` is a **living** document (cumulative, never archived), organized by the three `SCENARIOS.md` runtime actors, listing **every** scenario with a current support status (`✅/🟡/🔴 + phase`) and — for supported ones — a recipe against the current public API. It is *not* folded into a change spec (specs are per-change deltas that archive; a living how-to is not). Its **upkeep** is made durable two ways: (1) a normative requirement in the `integration-guide` capability (survives archive as living-spec truth); (2) an `openspec/config.yaml` `rules` entry on `tasks`/`specs` — *"a change that alters public API or a scenario's support status MUST update `docs/INTEGRATION.md` and re-mark the affected `SCENARIOS.md` rows"* — which the tooling **auto-injects into every future change's instructions**. This converts a recurring manual burden into a one-time enforced rule, so neither the roadmap nor each future spec has to "remember."
+
+**Seed depth:** first version is the **skeleton only** — the actor spine + a complete per-scenario status table (all 17 rows present, planned ones as "Phase N" stubs) — and recipes fill in as the guide is maintained. Rationale: prove the maintenance mechanism before investing in prose that would otherwise drift. *Alternative — seed full recipes now:* deferred; observe upkeep first. `docs/API-FIT.md` (a one-time gap snapshot) freezes as history once the guide exists.
+
+## Risks / Trade-offs
+
+- **Gate shape guessed wrong forces a contract break** → keep `Gate` minimal (border edge + open cells), design it against the Phase-2 stitch intent (P3) even though stitching isn't built; validate the shape with a paper walkthrough of a two-region seam.
+- **Cold generation blocks the frame** (~174 ms/32² cold) → acceptable at v1 startup (loading screen); document a size/latency envelope (P7); the game threads larger gens.
+- **Block expansion (N maze cells → ~2N+1 world cells) breeds off-by-one coordinate bugs** → centralize in `ToWorld`/`FromWorld` with tests; the façade owns the mapping, not consumers.
+- **`Area.ShallowCopy` aliases `_cells`/`_childAreas`** (§9 #1) → if the façade copies regions, use `Cell.Clone()` or a serialize round-trip for real isolation; never hand out an aliased region.
+- **Façade accidentally leaks `Area`** → `RegionView` returns value/read-only data only; no `Area`/`Cell` reference escapes; enforce with a contract test.
+- **Cross-repo change** (mazzzze lives in a sibling repo) → mazzzze edits are confined to the map engine; other systems untouched; the maze-gen additions are inert until consumed, so rollback = revert the mazzzze PR.
+
+## Migration Plan
+
+1. **maze-gen (additive):** add the façade namespace + `RegionView`/`RegionCell`/`Gate`/`RegionAddress`/`IRegionStore`/`World`; fix S6 longest-path; add the lossless-serialization path + examples. No existing public API removed → non-breaking for any current consumer.
+2. **mazzzze (behind its own PR):** replace the `MazeData` hash source with a façade consumer; wire spawn/goal to POIs; keep `ChunkManager`/`Chunk`. Rollback = revert this PR; the library additions remain dormant.
+3. **Freeze** the façade surface at merge; Phases 1–3 add capability behind it.
+
+## Open Questions
+
+- Same-assembly namespace (D1 recommendation) vs. sibling façade DLL — revisit only if hard isolation is later required.
+- Exact `Gate` representation (border edge + open-cell list vs. richer descriptor) — reserve now, refine with the Phase-2 stitch (P3) design.
+- Whether mazzzze v1 should opt into persistence (a real `IRegionStore`) or stay regenerate-at-startup — v1 default is regenerate; persistence is a free later opt-in behind the seam.
+- Region size / dimensionality defaults for mazzzze's single region — gameplay-driven, not a contract concern; `RegionAddress`/`Vector` stays N-D-ready.

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/proposal.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+`mazzzze` renders its map from a throwaway coordinate hash (`MazeData.IsFloor`): an unsolvable 70%-open lattice on a fixed 10000×10000 grid, with none of the library's real maze structure, rooms/caves, POIs, or the endless/persisted/stitched world the [PRD vision](../../../docs/PRD.md#1-vision) describes. Phase 0 defines the **single library contract** that `mazzzze` — and any Godot game — codes against, derived top-down from the vision so it survives the whole evolution to the MMO, and proves the contract by rewriting `mazzzze`'s map engine to consume it for one real generated region.
+
+## What Changes
+
+- **New façade** (a curated public surface over the existing `GeneratedWorld` pipeline) exposing the vision's protocol as one narrow, freezable waist:
+  - a **synchronous** region factory `GetOrCreate(regionAddress) → RegionView` — "generate a correct region here, once" (the game decides *when* to call it and off which thread);
+  - a **`RegionView`**: Block-style cells carrying `AreaType` / tags / links / markers, with **no leakage** of internal `Area` machinery (`ExtensibleObject`, HardLinks/BakedLinks, child areas);
+  - **POIs** — entrance/exit and dead-ends — surfaced as first-class metadata;
+  - **region gates** — the openings on a region's *border* (the future seam anchors) — whose shape is reserved now even though stitching is not built;
+  - **stable identity** — `(regionAddress, localCell) ⇄ world` — so the game keys mutations and fog-of-war to it across load/unload;
+  - an **`IRegionStore`** persistence seam the game implements (engine never regenerates a stored region).
+- **Give a region a place and gates** — a coordinate **address** (its place in the larger world) and **border gates** — two things a maze-gen `Area` does not model today (an `Area` is a closed box with only internal entrances).
+- **BREAKING (mazzzze):** rewrite `mazzzze`'s map engine — replace `MazeData.IsFloor`/`GetChunkData` and the `0`/`1` tile encoding with a façade-driven region renderer. **v1 generates ONE region at startup and plays it**; no persistence, no stitching, no streaming yet.
+- **Documented behavior changes on the maze-gen side** (with runnable examples): fix the longest-path marker **mis-tag (S6)** so entrance/exit POIs are correct; route the store seam through the **lossless `AreaSerializer`**, not the `Serialize()` debug-label **trap (D5)**.
+- **Living integration guide.** Introduce `docs/INTEGRATION.md` as the single, always-latest integrator how-to covering **every** [`SCENARIOS.md`](../../../docs/SCENARIOS.md) scenario (D1–D6, S1–S7, C1–C5) with its current support status. Keep it from rotting by encoding the maintenance obligation as an **OpenSpec `config.yaml` rule** — auto-injected into every future change's task instructions — plus a normative requirement, rather than as prose in the roadmap.
+- **Freeze the contract at this integration.** Later phases (persistence, seam-stitching, streaming/eviction) add capability *behind* the same surface — `mazzzze`'s calling code does not change shape.
+
+## Capabilities
+
+### New Capabilities
+- `region-facade`: the frozen library protocol — region factory + `RegionView` + POIs + gates + stable identity + `IRegionStore` seam; synchronous, deterministic, transport-agnostic, `Area`-internals-free.
+- `mazzzze-integration`: `mazzzze`'s map engine rewritten to consume the façade for one real region (render to `GridMap` + spawn/goal from POIs), replacing the `IsFloor` hash and validating the contract as the first reference consumer.
+- `integration-guide`: a living, always-latest integration guide (`docs/INTEGRATION.md`) covering every `SCENARIOS.md` scenario with current status, kept current by an enforced OpenSpec config rule rather than by roadmap prose.
+
+### Modified Capabilities
+<!-- None — openspec/specs is empty; this is the first spec set. The longest-path and
+     serialization fixes touch existing code but have no prior spec to modify; they are
+     captured as requirements under region-facade. -->
+
+## Impact
+
+- **maze-gen (`src` + new façade):** a new façade namespace/type set over the `GeneratedWorld` pipeline; bug fixes to longest-path tagging (`DijkstraDistance.FindLongestTrail`) and a documented lossless-serialization path for the store seam. Core `src` stays **BCL-only**; façade may live in `src` or a thin sibling assembly (decided in design).
+- **mazzzze (sibling repo `vasiliy-kiryukhin/mazzzze`, Godot 4 / net8.0):** map-engine rewrite — `MazeData` / `Chunk` / `ChunkManager` map-source replaced with a façade consumer; references `PlayersWorlds.Maps` (net8.0 — already the library's target). Game mechanics, creatures, and other systems owned by other developers are **not** touched.
+- **Docs & process:** new `docs/INTEGRATION.md` (living, scenario-complete); a new `openspec/config.yaml` rule that enforces its upkeep on every future change; `docs/API-FIT.md` becomes a historical snapshot the guide supersedes for forward-looking guidance.
+- **Contract stability:** this is the freeze point; Phases 1–3 capability lands behind the same surface.

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/specs/integration-guide/spec.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/specs/integration-guide/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: A living integration guide covers every scenario with current status
+
+The project SHALL maintain `docs/INTEGRATION.md` as the single, always-latest integration guide. It MUST be organized by the runtime actors in `docs/SCENARIOS.md` (game developer, game server, in-game client) and MUST list every scenario defined in `docs/SCENARIOS.md` with its current support status. For a supported scenario it MUST describe how to integrate it against the current public API; for a not-yet-supported scenario it MUST include a stub marking the phase it is planned for, rather than omitting it.
+
+#### Scenario: Every scenario is present with a status
+- **WHEN** a reader opens `docs/INTEGRATION.md`
+- **THEN** every scenario ID in `docs/SCENARIOS.md` (D1–D6, S1–S7, C1–C5) appears with a current support status (supported / partial / planned + phase)
+
+#### Scenario: Not-yet-integratable scenarios are stubbed, not dropped
+- **WHEN** a scenario has no current integration path
+- **THEN** the guide lists it as a "planned — Phase N" stub so coverage is complete by construction
+
+#### Scenario: A supported scenario carries an integration recipe
+- **WHEN** a scenario is marked supported
+- **THEN** the guide shows how to integrate it against the current public API (the skeleton may defer recipe prose, but the section exists)
+
+### Requirement: Guide upkeep is enforced by an OpenSpec config rule
+
+Maintenance of the guide SHALL be enforced by a rule in `openspec/config.yaml` rather than by roadmap prose, so the obligation is auto-injected into every future change's artifact instructions. Any change that alters the public API or changes a scenario's support status MUST update `docs/INTEGRATION.md` and re-mark the affected `docs/SCENARIOS.md` rows within the same change.
+
+#### Scenario: The rule surfaces in future change instructions
+- **WHEN** an author generates task instructions for any future change (`openspec instructions tasks`)
+- **THEN** the config rule reminding them to update `docs/INTEGRATION.md` for contract or status changes appears in those instructions
+
+#### Scenario: A contract-altering change updates the guide
+- **WHEN** a change adds, modifies, or removes public API, or changes a scenario's support status
+- **THEN** the same change updates `docs/INTEGRATION.md` and the affected `docs/SCENARIOS.md` status rows

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/specs/mazzzze-integration/spec.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/specs/mazzzze-integration/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: mazzzze map engine sources its map from the façade, not the hash
+
+`mazzzze`'s map engine SHALL obtain its map by generating one region through the maze-gen façade at game start, replacing the `MazeData.IsFloor` coordinate hash and the fixed 10000×10000 grid. The removed hash, the `0`/`1` tile encoding, and the fixed world bounds MUST NOT remain the source of map data.
+
+#### Scenario: Startup generates one real region
+- **WHEN** the game starts
+- **THEN** the map engine calls the façade `GetOrCreate` once and holds the returned `RegionView` as the map for the session
+
+#### Scenario: No player-facing dependency on IsFloor remains
+- **WHEN** the map is queried for what occupies a cell
+- **THEN** the answer comes from the `RegionView`, not from `MazeData.IsFloor`
+
+### Requirement: Chunks render from region cells while keeping residency
+
+`mazzzze` SHALL keep its chunk load/unload residency ring and `GridMap` rendering, changing only the data source: a chunk's cells are sampled from the resident `RegionView` and mapped to tiles by cell payload (wall vs floor, and area type where the game distinguishes rooms/caves/corridors).
+
+#### Scenario: A chunk renders sampled region cells
+- **WHEN** a chunk is loaded
+- **THEN** its `GridMap` cells are set from the corresponding `RegionView` cells rather than from `GetChunkData`'s hash output
+
+#### Scenario: Residency ring is preserved
+- **WHEN** the player moves
+- **THEN** the existing chunk load/unload ring continues to operate, now sourcing cells from the resident region
+
+### Requirement: Spawn and goal come from region POIs
+
+`mazzzze` SHALL place the player start/spawn and the level goal from the region's entrance/exit POIs rather than from hard-coded fixed cells, and MAY place content on dead-end POIs.
+
+#### Scenario: Player spawns at the region entrance
+- **WHEN** the region is generated at startup
+- **THEN** the player start is derived from the region's entrance POI, not a hard-coded `(1,1)`
+
+#### Scenario: Goal is the region exit
+- **WHEN** the game marks the level goal
+- **THEN** it uses the region's exit POI, and the entrance and exit are distinct correct cells
+
+### Requirement: v1 is single-region with no persistence, stitching, or streaming
+
+The Phase-0 `mazzzze` integration SHALL use exactly one region for the whole session with a no-op store (regenerate at startup). Multi-region worlds, seam-stitching, cross-seam player transfer, and region streaming/eviction MUST NOT be required for v1 and are added later behind the same unchanged façade.
+
+#### Scenario: One region for the session
+- **WHEN** the game runs a session
+- **THEN** it uses a single generated region and does not request neighbors, stitch, or stream additional regions
+
+#### Scenario: Contract shape unchanged when capability is added later
+- **WHEN** a later phase adds persistence, stitching, or streaming
+- **THEN** it is introduced behind the existing façade surface without changing the calls v1 makes

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/specs/region-facade/spec.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/specs/region-facade/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Region factory generates one bounded region on demand
+
+The façade SHALL expose a synchronous factory that generates exactly one bounded region for a given coordinate address and returns it as a `RegionView`. The call MUST NOT be endless or stream; it generates a single region and returns. The caller (game) decides when and on which thread to invoke it.
+
+#### Scenario: Generate a region for an address
+- **WHEN** the game calls `GetOrCreate(address)` for an address with no stored region
+- **THEN** the façade generates one region from its own seed and returns a `RegionView` for that address
+
+#### Scenario: Region is a correct, solvable map
+- **WHEN** a region is generated
+- **THEN** the returned `RegionView` represents a solvable maze with no orphaned connectable cells, honoring the same correctness invariants the underlying pipeline guarantees
+
+#### Scenario: Generation is deterministic for a fixed seed
+- **WHEN** two regions are generated for the same address with the same seed
+- **THEN** their `RegionView` cell data is identical
+
+### Requirement: RegionView exposes Block cells with a typed payload and no Area internals
+
+The façade SHALL return region cell data as a **Block** grid (walls occupy their own cells) via a `RegionView` whose cells carry passability, `AreaType`, block tags, links, and markers. The `RegionView` MUST NOT expose any internal `Area` or `Cell` object, `ExtensibleObject` attachment, or Border/Block conversion machinery.
+
+#### Scenario: Cells report wall vs floor
+- **WHEN** the game reads a cell from a `RegionView`
+- **THEN** the cell reports whether it is passable (floor) or a wall
+
+#### Scenario: Cells carry area type and markers
+- **WHEN** the game reads a cell that belongs to a hall, cave, fill, or maze corridor, or that was marked as a dead-end or path endpoint
+- **THEN** the cell exposes its `AreaType`, tags, and markers so the game can choose tiles and spawns
+
+#### Scenario: No Area internals leak
+- **WHEN** the game holds a `RegionView`
+- **THEN** it cannot reach an `Area`, `Cell`, HardLinks/BakedLinks, or child-area structure through the façade's public surface
+
+### Requirement: Regions expose first-class POIs with correct endpoint tagging
+
+The façade SHALL surface points of interest — the region's entrance/exit pair and its dead-ends — as first-class metadata on the `RegionView`. The entrance/exit endpoints MUST be tagged on the correct cells (fixing the longest-path mis-tag where the end marker landed on the start cell and trail cells were mis-tagged).
+
+#### Scenario: Entrance and exit resolve to distinct correct cells
+- **WHEN** the game reads the entrance and exit POIs of a region
+- **THEN** they resolve to two distinct cells at the ends of the guaranteed longest path, each tagged on its own cell
+
+#### Scenario: Dead-ends are enumerable
+- **WHEN** the game reads the dead-end POIs of a region
+- **THEN** it receives the set of dead-end cells for placing loot or content
+
+### Requirement: Regions carry a place and border gates
+
+A `RegionView` SHALL carry its coordinate **address** (its place on the region lattice) and its **gates** — the openings on its border that are the anchors a neighboring region connects to. The `Gate` shape is part of the contract from this release even though gate-aware stitching generation is deferred.
+
+#### Scenario: Region reports its address
+- **WHEN** the game reads a `RegionView`
+- **THEN** it can read the `RegionAddress` the region was generated for
+
+#### Scenario: Region exposes its border gates
+- **WHEN** the game reads a region's gates
+- **THEN** it receives, per gate, the border edge and the open cells along it, in a shape a future neighbor could consume as connection anchors
+
+### Requirement: Stable region-relative identity with derived world coordinates
+
+The façade SHALL define cell identity as `(RegionAddress, localCell)` and provide `ToWorld`/`FromWorld` helpers that derive absolute world coordinates from a region address, region size, and local cell. Identity MUST be stable across a region unload/reload so the game can key fog-of-war and mutations to it.
+
+#### Scenario: Local identity round-trips through world coordinates
+- **WHEN** the game maps a `(RegionAddress, localCell)` to world coordinates and back with `ToWorld`/`FromWorld`
+- **THEN** it recovers the original `(RegionAddress, localCell)`
+
+#### Scenario: Identity survives reload
+- **WHEN** a region is unloaded and later reloaded for the same address
+- **THEN** a given cell resolves to the same `(RegionAddress, localCell)` identity as before
+
+### Requirement: Persistence seam is generate-once and lossless
+
+The façade SHALL accept an `IRegionStore` that the game implements, and `GetOrCreate` MUST load a stored region rather than regenerate it when one exists, generating and saving only on a store miss. Serialization used by the seam MUST be lossless (round-trippable), not the `Serialize()`/`ToString()` debug-label form.
+
+#### Scenario: Stored region is loaded, not regenerated
+- **WHEN** `GetOrCreate(address)` is called and the store reports a region for that address
+- **THEN** the façade returns the stored region and does not regenerate it
+
+#### Scenario: Missing region is generated then saved
+- **WHEN** `GetOrCreate(address)` is called and the store has no region for that address
+- **THEN** the façade generates the region, saves it to the store, and returns it
+
+#### Scenario: Round-trip through the store preserves cells
+- **WHEN** a region is saved and reloaded through the store seam
+- **THEN** the reloaded `RegionView` has cell data identical to the original
+
+#### Scenario: No-op store regenerates each call
+- **WHEN** a `NullRegionStore` (always-miss, never-save) is supplied and `GetOrCreate` is called at startup
+- **THEN** a fresh region is generated for use and nothing is persisted

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/specs/region-facade/spec.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/specs/region-facade/spec.md
@@ -87,3 +87,43 @@ The façade SHALL accept an `IRegionStore` that the game implements, and `GetOrC
 #### Scenario: No-op store regenerates each call
 - **WHEN** a `NullRegionStore` (always-miss, never-save) is supplied and `GetOrCreate` is called at startup
 - **THEN** a fresh region is generated for use and nothing is persisted
+
+### Requirement: Region generation is configurable by an intent recipe
+
+The façade SHALL let the caller choose how a region is generated via an immutable `RegionRecipe` — algorithm, fill density, and cell shape — rather than baking them. It MUST provide intent presets and fluent overrides, and MUST default so that the no-argument path still works. The maze algorithm MUST be selectable from a discoverable built-in set AND extensible with a caller-supplied `MazeGenerator` via an escape hatch, without the façade exposing renderer types.
+
+#### Scenario: A preset generates without extra configuration
+- **WHEN** a caller uses a `RegionRecipe` preset (e.g. `Maze`)
+- **THEN** the region generates with that preset's algorithm/fill/cells and no further configuration is required
+
+#### Scenario: Overrides are additive and non-mutating
+- **WHEN** a caller applies `WithAlgorithm` / `WithFill` / `WithCells` to a recipe
+- **THEN** a new recipe with that override is returned and the original recipe is unchanged
+
+#### Scenario: A custom algorithm can be supplied
+- **WHEN** a caller supplies a custom `MazeGenerator` subtype via the algorithm escape hatch
+- **THEN** the region is generated with that algorithm, and no renderer type appears on the façade's public surface
+
+### Requirement: World holds shared parameters; region kind is chosen per call and binds at creation
+
+Creating a `World` SHALL fix the shared, inherited parameters (seed, store, region footprint, default recipe). `GetOrCreate` SHALL accept a per-call recipe that overrides the default for that region only. A region's kind MUST bind at first generation: a later `GetOrCreate` on an already-stored address returns the stored region and ignores any newly supplied recipe.
+
+#### Scenario: Different regions can be different kinds
+- **WHEN** two different addresses are generated with different recipes
+- **THEN** each region reflects its own recipe
+
+#### Scenario: Recipe is ignored once a region exists
+- **WHEN** `GetOrCreate(address, recipeB)` is called for an address already generated with `recipeA`
+- **THEN** the stored region (from `recipeA`) is returned and `recipeB` is ignored
+
+### Requirement: regionSize is the region's world footprint
+
+`regionSize` SHALL be the region's footprint in the world, in Block cells — the uniform lattice pitch — and MUST equal exactly what `RegionView.Size` reports. The number of corridors/rooms within the footprint is derived internally from the recipe's cell sizing; the caller does not specify maze-cell counts.
+
+#### Scenario: The requested footprint is the reported size
+- **WHEN** a world is created with a given `regionSize` and a region is generated
+- **THEN** the returned `RegionView.Size` equals that `regionSize` exactly, in every dimension
+
+#### Scenario: A footprint too small to hold a region is rejected
+- **WHEN** `regionSize` cannot fit at least one maze cell for the chosen cell sizing
+- **THEN** generation fails with a clear error rather than producing a degenerate region

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/specs/region-facade/spec.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/specs/region-facade/spec.md
@@ -127,3 +127,15 @@ Creating a `World` SHALL fix the shared, inherited parameters (seed, store, regi
 #### Scenario: A footprint too small to hold a region is rejected
 - **WHEN** `regionSize` cannot fit at least one maze cell for the chosen cell sizing
 - **THEN** generation fails with a clear error rather than producing a degenerate region
+
+### Requirement: Regions can contain rooms of every supported kind
+
+A recipe SHALL be able to request rooms placed into the region — walkable halls and caves, and impassable blocked areas (the room-capable maze-gen area types) — sized in world cells, with open-ended semantic tags, and mixable within one recipe. Rooms MUST render into the region (halls/caves as walkable open space, blocked areas as impassable) and MUST NOT break the region's entrance/exit POIs.
+
+#### Scenario: A room preset opens walkable space a plain maze lacks
+- **WHEN** a region is generated from a room preset (e.g. Dungeon or Caverns)
+- **THEN** it contains contiguous walkable areas larger than a one-cell corridor, which a plain maze does not
+
+#### Scenario: Every room kind generates a valid region
+- **WHEN** a region is generated with Hall, Cave, or Blocked rooms
+- **THEN** the region generates without error and still has distinct entrance and exit POIs

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/tasks.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/tasks.md
@@ -55,4 +55,5 @@ Done on the sibling `mazzzze` repo, branch `integrate-maze-gen-facade`, commit `
 - [x] 7.4 Tests: footprint honored exactly (incl. non-square) + too-small throws; per-region recipe changes content; recipe ignored when stored; algorithm/recipe immutability; contract test still forbids renderer types
 - [x] 7.5 Update `docs/INTEGRATION.md` quickstart (footprint `regionSize`, per-region recipe, algorithm selection) and `design.md` (D9/D10) + spec
 - [x] 7.6 Update mazzzze `MazeData` to the new API (footprint `regionSize`, explicit `RegionRecipe`)
-- [ ] 7.7 **NOT STARTED (next slice):** room support — `RoomKind` enum + open tags, `WithRooms`/`AddRoom`, `Dungeon`/`Caverns` presets, mapping to `WithAreas`
+- [x] 7.7 Room generation: `RoomKind` (Hall/Cave/Blocked = all room-capable area types) + open tags, `RegionRecipe.WithRooms(count, min, max, kind, tags)`, `Dungeon`/`Caverns` presets, mapped to `WithAreas` in Manual mode (sidesteps the >19-area crash); sizes in world cells snapped to the maze grid; fixed the `BasicAreaGenerator` empty-tags crash; tests (rooms open 2×2 space a maze lacks, all kinds valid). Wired into mazzzze (AldousBroder + Hall rooms)
+- [ ] 7.8 **NOT STARTED (next slice):** room *metadata* on `RegionView` (per-room kind/tags/bounds, baked into the Block area so it survives persistence like POIs) and explicit `AddRoom(position, …)` placement

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/tasks.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/tasks.md
@@ -21,26 +21,28 @@
 - [x] 3.2 Implement `World.GetOrCreate(address)`: `TryLoad` → hit returns stored region; miss generates (per-address seed via `RandomSource.FromSeed`) + `Save` + returns; synchronous, no streaming
 - [x] 3.3 Wire generation to the existing `GeneratedWorld` pipeline (Block-styled, area-populated, POIs marked as tags)
 - [x] 3.4 Tests: deterministic generation for a fixed seed; stored region is loaded not regenerated (different-seed-shared-store proof); store round-trip preserves cells + POIs; `NullRegionStore` regenerates and persists nothing
-- [ ] 3.5 Measure and document a region-size → generation-latency envelope (P7) so the game knows frame-safe vs. must-thread sizes — measured; documented in `docs/INTEGRATION.md` (see group 5)
+- [x] 3.5 Measure and document a region-size → generation-latency envelope (P7) so the game knows frame-safe vs. must-thread sizes — measured (8²–64²) and documented in `docs/INTEGRATION.md`; ≤16² main-thread-safe, 32²+ thread it
 
 ## 4. mazzzze map-engine rewrite (mazzzze-integration, sibling repo — its own PR)
 
-- [ ] 4.1 Add a `PlayersWorlds.Maps` (net8.0) reference to the `mazzzze` project
-- [ ] 4.2 Add a map-engine node that calls the façade `GetOrCreate` once at startup with a `NullRegionStore` and holds the returned `RegionView`
-- [ ] 4.3 Change `Chunk`/`ChunkManager` to sample cells from the resident `RegionView` (mapped to tiles by cell payload) instead of `MazeData.GetChunkData`/`IsFloor`; keep the load/unload residency ring
-- [ ] 4.4 Derive player spawn from the region entrance POI and the level goal from the exit POI (remove hard-coded `(1,1)`/fixed entrance/exit)
-- [ ] 4.5 Remove `MazeData.IsFloor`, the `0`/`1` encoding, and the fixed 10000×10000 bounds as the map source
-- [ ] 4.6 Smoke-run `mazzzze`: player walks a solvable, room-bearing region with a correct entrance/exit; other game systems (creatures, mechanics) unaffected
+Done on the sibling `mazzzze` repo, branch `integrate-maze-gen-facade`, commit `c911af7` (own PR). Minimal-disruption (D7): `MazeData`'s public surface preserved, internals swapped to the façade, so `ChunkManager`/`Chunk`/`Minimap`/`Player` are untouched.
+
+- [x] 4.1 Add a `PlayersWorlds.Maps` (net8.0) reference to the `mazzzze` project — `ProjectReference` to the sibling `src/` checkout (NuGet/DLL packaging is the CI/release follow-up)
+- [x] 4.2 Add a map-engine node that calls the façade `GetOrCreate` once at startup with a `NullRegionStore` and holds the returned `RegionView` — `MazeData` (now façade-backed) generates one region in `_Ready`
+- [x] 4.3 Change `Chunk`/`ChunkManager` to sample cells from the resident `RegionView` instead of `MazeData.GetChunkData`/`IsFloor`; keep the load/unload residency ring — `IsFloor`/`GetChunkData` now sample the region; the residency ring is unchanged
+- [x] 4.4 Derive player spawn from the region entrance POI and the level goal from the exit POI (remove hard-coded `(1,1)`/fixed entrance/exit) — `PlayerStartCell`/`EntranceCell`/`ExitCell` come from POIs
+- [x] 4.5 Remove `MazeData.IsFloor`, the `0`/`1` encoding, and the fixed 10000×10000 bounds as the map source — the hash is gone; bounds are the region's Block size (the `0`/`1` values remain only as `Chunk.Setup`'s tile ids, i.e. the render contract, not the map source)
+- [ ] 4.6 Smoke-run `mazzzze`: player walks a solvable, room-bearing region with a correct entrance/exit; other game systems unaffected — ⚠️ NOT COMPLETE: the project **compiles** (0 errors) and the region logic is covered by maze-gen tests, but launching the Godot game is a GUI action that needs the user's Godot editor; the in-editor walk-through is pending
 
 ## 5. Living integration guide (integration-guide)
 
-- [ ] 5.1 Add the enforcement rule to `openspec/config.yaml` under `rules.tasks` (and `rules.specs`): a change that alters public API or a scenario's support status MUST update `docs/INTEGRATION.md` and re-mark the affected `docs/SCENARIOS.md` rows
-- [ ] 5.2 Create `docs/INTEGRATION.md` **skeleton**: header (living doc; supersedes `API-FIT.md` for forward guidance), a "status at a glance" table with all 17 `SCENARIOS.md` rows (D1–D6, S1–S7, C1–C5) marked with current status + phase, and the three actor sections with per-scenario placeholders
-- [ ] 5.3 Fill the Phase-0-supported rows enough to be usable (at minimum S1 region-factory and the C-actor consume/render/identity paths reference the façade usage sketch); leave 🔴 rows as "planned — Phase N" stubs
-- [ ] 5.4 Add a one-line pointer to `docs/INTEGRATION.md` from `docs/ROADMAP.md` References (canonical living integration doc), and a memory pointer in `MEMORY.md`
+- [x] 5.1 Add the enforcement rule to `openspec/config.yaml` under `rules.tasks` (and `rules.specs`): a change that alters public API or a scenario's support status MUST update `docs/INTEGRATION.md` and re-mark the affected `docs/SCENARIOS.md` rows
+- [x] 5.2 Create `docs/INTEGRATION.md` **skeleton**: header (living doc; supersedes `API-FIT.md` for forward guidance), a "status at a glance" table with all `SCENARIOS.md` rows (D1–D6, S1–S7, C1–C5) marked with current status + phase, and the three actor sections with per-scenario content
+- [x] 5.3 Fill the Phase-0-supported rows enough to be usable (façade quickstart, S1 region-factory, S3 persistence, C-actor consume/render/identity, latency envelope, mazzzze reference); left 🔴 rows as "planned — Phase N" stubs
+- [x] 5.4 Add a one-line pointer to `docs/INTEGRATION.md` from `docs/ROADMAP.md` References (canonical living integration doc), and a memory pointer in `MEMORY.md`. Also dogfooded the rule: re-marked `SCENARIOS.md` S1 (🔴→✅) and S3 (🟡→✅)
 
 ## 6. Freeze, validate, document
 
-- [ ] 6.1 Run `openspec validate maze-gen-mazzzze-phase0-contract --strict` and `make ci` (lint + build + test) green
-- [ ] 6.2 Update `docs/ROADMAP.md` §3 to mark the Phase-0 contract as defined and frozen at this integration
-- [ ] 6.3 Note the frozen façade surface as the freeze point; record that Phases 1–3 add capability behind it without changing the calls v1 makes
+- [x] 6.1 Run `openspec validate maze-gen-mazzzze-phase0-contract --strict` (valid) and `make ci` (lint + build + 334 tests) green
+- [x] 6.2 Update `docs/ROADMAP.md` §3 to mark the Phase-0 contract as defined and frozen at this integration (Phase 0 ✅ frozen; Phase 1 🚧 largely landed)
+- [x] 6.3 Note the frozen façade surface as the freeze point; record that Phases 1–3 add capability behind it without changing the calls v1 makes (design.md "As-built freeze" + ROADMAP §3)

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/tasks.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/tasks.md
@@ -7,21 +7,21 @@
 
 ## 2. Façade contract types (region-facade)
 
-- [ ] 2.1 Add the façade namespace in `src` (one DLL, core stays BCL-only); decide final namespace name
-- [ ] 2.2 Define `RegionAddress` (a `Vector`, N-D-ready) and `ToWorld`/`FromWorld` identity helpers with round-trip tests, accounting for Block expansion (N maze cells → ~2N+1 world cells)
-- [ ] 2.3 Define `RegionCell` value type: passability (wall/floor), `AreaType`, block tags, links, markers — no `Area`/`Cell` object exposed
-- [ ] 2.4 Define `RegionView`: read-only Block cell accessor + `RegionAddress` + `Size`, backed by a baked Block region; ensure isolation (use `Cell.Clone()`/serialize round-trip, never aliased `ShallowCopy`)
-- [ ] 2.5 Define POIs on `RegionView`: entrance/exit pair (from the fixed longest-path) and dead-ends (from `DeadEndsExtension`)
-- [ ] 2.6 Define `Gate` (border edge + open cells along it) and `RegionView.Gates`; surface gates a region has (gate-aware *generation* deferred to Phase 2)
-- [ ] 2.7 Add a contract test asserting no `Area`/`Cell`/`ExtensibleObject`/child-area reference is reachable through the façade's public surface
+- [x] 2.1 Add the façade namespace in `src` (one DLL, core stays BCL-only); decide final namespace name — `PlayersWorlds.Maps.World` under `src/world/`
+- [x] 2.2 Define `RegionAddress` (a `Vector`, N-D-ready) and `ToWorld`/`FromWorld` identity helpers with round-trip tests, accounting for Block expansion (N maze cells → ~2N+1 world cells). Note: `ToWorld`/`FromWorld` operate in the actual Block size (read from `RegionView.Size`), so expansion is handled by using the real rendered size rather than assuming 2N+1
+- [x] 2.3 Define `RegionCell` value type: passability (wall/floor from the trail tag), `AreaType`, block tags — no `Area`/`Cell` object exposed. Note: dropped `links` and `markers` — grounding showed Block cells carry no links, and POIs are surfaced at region level via `RegionView.Pois`
+- [x] 2.4 Define `RegionView`: read-only Block cell accessor + `RegionAddress` + `Size`, backed by a baked Block region; isolation via factory-owned/deserialized `Area` (never aliased `ShallowCopy`)
+- [x] 2.5 Define POIs on `RegionView`: entrance/exit pair (from the fixed longest-path) and dead-ends (from `DeadEndsExtension`), bridged from Border→Block coords and baked as serializable cell tags so they survive persistence
+- [x] 2.6 Define `Gate` (border edge + open cells along it) and `RegionView.Gates`; surface gates a region has (gate-aware *generation* deferred to Phase 2)
+- [x] 2.7 Add a contract test asserting no `Area`/`Cell`/`ExtensibleObject`/child-area reference is reachable through the façade's public surface (reflection over the `PlayersWorlds.Maps.World` public surface)
 
 ## 3. Region factory + persistence seam (region-facade)
 
-- [ ] 3.1 Define `IRegionStore { TryLoad(address, out region); Save(address, region); }` and a `NullRegionStore` (always-miss, never-save)
-- [ ] 3.2 Implement `World.GetOrCreate(address)`: `TryLoad` → hit returns stored region; miss generates (own seed) + `Save` + returns; synchronous, no streaming
-- [ ] 3.3 Wire generation to the existing `GeneratedWorld` pipeline (Block-styled, area-populated, POIs marked)
-- [ ] 3.4 Tests: deterministic generation for a fixed seed; stored region is loaded not regenerated; store round-trip preserves cells; `NullRegionStore` regenerates and persists nothing
-- [ ] 3.5 Measure and document a region-size → generation-latency envelope (P7) so the game knows frame-safe vs. must-thread sizes
+- [x] 3.1 Define `IRegionStore { TryLoad(address, out serialized); Save(address, serialized); }` and a `NullRegionStore` (always-miss, never-save). Note: the store persists opaque serialized blobs keyed by address (the engine owns lossless `AreaSerializer` (de)serialization), rather than dealing in `RegionView` — cleaner for a game's blob store
+- [x] 3.2 Implement `World.GetOrCreate(address)`: `TryLoad` → hit returns stored region; miss generates (per-address seed via `RandomSource.FromSeed`) + `Save` + returns; synchronous, no streaming
+- [x] 3.3 Wire generation to the existing `GeneratedWorld` pipeline (Block-styled, area-populated, POIs marked as tags)
+- [x] 3.4 Tests: deterministic generation for a fixed seed; stored region is loaded not regenerated (different-seed-shared-store proof); store round-trip preserves cells + POIs; `NullRegionStore` regenerates and persists nothing
+- [ ] 3.5 Measure and document a region-size → generation-latency envelope (P7) so the game knows frame-safe vs. must-thread sizes — measured; documented in `docs/INTEGRATION.md` (see group 5)
 
 ## 4. mazzzze map-engine rewrite (mazzzze-integration, sibling repo — its own PR)
 

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/tasks.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/tasks.md
@@ -46,3 +46,13 @@ Done on the sibling `mazzzze` repo, branch `integrate-maze-gen-facade`, commit `
 - [x] 6.1 Run `openspec validate maze-gen-mazzzze-phase0-contract --strict` (valid) and `make ci` (lint + build + 334 tests) green
 - [x] 6.2 Update `docs/ROADMAP.md` §3 to mark the Phase-0 contract as defined and frozen at this integration (Phase 0 ✅ frozen; Phase 1 🚧 largely landed)
 - [x] 6.3 Note the frozen façade surface as the freeze point; record that Phases 1–3 add capability behind it without changing the calls v1 makes (design.md "As-built freeze" + ROADMAP §3)
+
+## 7. Configuration surface & lifecycle (region-facade, follow-up slice)
+
+- [x] 7.1 `RegionAlgorithm`: discoverable built-ins for the six generators + `Custom<T>()`/`Custom(Type)` escape hatch (validates subtype + parameterless ctor); no renderer types on the surface
+- [x] 7.2 `RegionRecipe`: immutable, intent presets (`Maze`, `Corridors`), fluent `WithAlgorithm`/`WithFill`/`WithCells`; square 1×1 default cells; cell shape lives here (no `Maze2DRendererOptions` on the façade)
+- [x] 7.3 `World`: `regionSize` = world footprint (== `RegionView.Size`, generation renders into a footprint-sized canvas, maze-cell count derived); `defaultRecipe` ctor arg; `GetOrCreate(address, recipe?)`; recipe binds at first generation
+- [x] 7.4 Tests: footprint honored exactly (incl. non-square) + too-small throws; per-region recipe changes content; recipe ignored when stored; algorithm/recipe immutability; contract test still forbids renderer types
+- [x] 7.5 Update `docs/INTEGRATION.md` quickstart (footprint `regionSize`, per-region recipe, algorithm selection) and `design.md` (D9/D10) + spec
+- [x] 7.6 Update mazzzze `MazeData` to the new API (footprint `regionSize`, explicit `RegionRecipe`)
+- [ ] 7.7 **NOT STARTED (next slice):** room support — `RoomKind` enum + open tags, `WithRooms`/`AddRoom`, `Dungeon`/`Caverns` presets, mapping to `WithAreas`

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/tasks.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/tasks.md
@@ -1,0 +1,46 @@
+## 1. maze-gen behavior fixes (documented with examples)
+
+- [ ] 1.1 Fix `DijkstraDistance.FindLongestTrail` longest-path mis-tag (end marker lands on start cell; trail cells mis-tagged) so entrance/exit resolve to two distinct correct cells (§9 #2/#3)
+- [ ] 1.2 Add/adjust unit tests asserting the entrance and exit tags land on the correct, distinct cells
+- [ ] 1.3 Confirm the lossless round-trip path is `AreaSerializer.Serialize/Deserialize`; add a test asserting `GeneratedWorld.Serialize()`/`Area.ToString()` are debug labels that MUST NOT be fed to the store seam (documents the D5 trap)
+- [ ] 1.4 Add a runnable example (CLI `usecase`/snippet) demonstrating the corrected POIs and the lossless round-trip
+
+## 2. Façade contract types (region-facade)
+
+- [ ] 2.1 Add the façade namespace in `src` (one DLL, core stays BCL-only); decide final namespace name
+- [ ] 2.2 Define `RegionAddress` (a `Vector`, N-D-ready) and `ToWorld`/`FromWorld` identity helpers with round-trip tests, accounting for Block expansion (N maze cells → ~2N+1 world cells)
+- [ ] 2.3 Define `RegionCell` value type: passability (wall/floor), `AreaType`, block tags, links, markers — no `Area`/`Cell` object exposed
+- [ ] 2.4 Define `RegionView`: read-only Block cell accessor + `RegionAddress` + `Size`, backed by a baked Block region; ensure isolation (use `Cell.Clone()`/serialize round-trip, never aliased `ShallowCopy`)
+- [ ] 2.5 Define POIs on `RegionView`: entrance/exit pair (from the fixed longest-path) and dead-ends (from `DeadEndsExtension`)
+- [ ] 2.6 Define `Gate` (border edge + open cells along it) and `RegionView.Gates`; surface gates a region has (gate-aware *generation* deferred to Phase 2)
+- [ ] 2.7 Add a contract test asserting no `Area`/`Cell`/`ExtensibleObject`/child-area reference is reachable through the façade's public surface
+
+## 3. Region factory + persistence seam (region-facade)
+
+- [ ] 3.1 Define `IRegionStore { TryLoad(address, out region); Save(address, region); }` and a `NullRegionStore` (always-miss, never-save)
+- [ ] 3.2 Implement `World.GetOrCreate(address)`: `TryLoad` → hit returns stored region; miss generates (own seed) + `Save` + returns; synchronous, no streaming
+- [ ] 3.3 Wire generation to the existing `GeneratedWorld` pipeline (Block-styled, area-populated, POIs marked)
+- [ ] 3.4 Tests: deterministic generation for a fixed seed; stored region is loaded not regenerated; store round-trip preserves cells; `NullRegionStore` regenerates and persists nothing
+- [ ] 3.5 Measure and document a region-size → generation-latency envelope (P7) so the game knows frame-safe vs. must-thread sizes
+
+## 4. mazzzze map-engine rewrite (mazzzze-integration, sibling repo — its own PR)
+
+- [ ] 4.1 Add a `PlayersWorlds.Maps` (net8.0) reference to the `mazzzze` project
+- [ ] 4.2 Add a map-engine node that calls the façade `GetOrCreate` once at startup with a `NullRegionStore` and holds the returned `RegionView`
+- [ ] 4.3 Change `Chunk`/`ChunkManager` to sample cells from the resident `RegionView` (mapped to tiles by cell payload) instead of `MazeData.GetChunkData`/`IsFloor`; keep the load/unload residency ring
+- [ ] 4.4 Derive player spawn from the region entrance POI and the level goal from the exit POI (remove hard-coded `(1,1)`/fixed entrance/exit)
+- [ ] 4.5 Remove `MazeData.IsFloor`, the `0`/`1` encoding, and the fixed 10000×10000 bounds as the map source
+- [ ] 4.6 Smoke-run `mazzzze`: player walks a solvable, room-bearing region with a correct entrance/exit; other game systems (creatures, mechanics) unaffected
+
+## 5. Living integration guide (integration-guide)
+
+- [ ] 5.1 Add the enforcement rule to `openspec/config.yaml` under `rules.tasks` (and `rules.specs`): a change that alters public API or a scenario's support status MUST update `docs/INTEGRATION.md` and re-mark the affected `docs/SCENARIOS.md` rows
+- [ ] 5.2 Create `docs/INTEGRATION.md` **skeleton**: header (living doc; supersedes `API-FIT.md` for forward guidance), a "status at a glance" table with all 17 `SCENARIOS.md` rows (D1–D6, S1–S7, C1–C5) marked with current status + phase, and the three actor sections with per-scenario placeholders
+- [ ] 5.3 Fill the Phase-0-supported rows enough to be usable (at minimum S1 region-factory and the C-actor consume/render/identity paths reference the façade usage sketch); leave 🔴 rows as "planned — Phase N" stubs
+- [ ] 5.4 Add a one-line pointer to `docs/INTEGRATION.md` from `docs/ROADMAP.md` References (canonical living integration doc), and a memory pointer in `MEMORY.md`
+
+## 6. Freeze, validate, document
+
+- [ ] 6.1 Run `openspec validate maze-gen-mazzzze-phase0-contract --strict` and `make ci` (lint + build + test) green
+- [ ] 6.2 Update `docs/ROADMAP.md` §3 to mark the Phase-0 contract as defined and frozen at this integration
+- [ ] 6.3 Note the frozen façade surface as the freeze point; record that Phases 1–3 add capability behind it without changing the calls v1 makes

--- a/openspec/changes/maze-gen-mazzzze-phase0-contract/tasks.md
+++ b/openspec/changes/maze-gen-mazzzze-phase0-contract/tasks.md
@@ -1,9 +1,9 @@
 ## 1. maze-gen behavior fixes (documented with examples)
 
-- [ ] 1.1 Fix `DijkstraDistance.FindLongestTrail` longest-path mis-tag (end marker lands on start cell; trail cells mis-tagged) so entrance/exit resolve to two distinct correct cells (§9 #2/#3)
-- [ ] 1.2 Add/adjust unit tests asserting the entrance and exit tags land on the correct, distinct cells
-- [ ] 1.3 Confirm the lossless round-trip path is `AreaSerializer.Serialize/Deserialize`; add a test asserting `GeneratedWorld.Serialize()`/`Area.ToString()` are debug labels that MUST NOT be fed to the store seam (documents the D5 trap)
-- [ ] 1.4 Add a runnable example (CLI `usecase`/snippet) demonstrating the corrected POIs and the lossless round-trip
+- [x] 1.1 Fix `DijkstraDistance.FindLongestTrail` longest-path mis-tag (end marker lands on start cell; trail cells mis-tagged) so entrance/exit resolve to two distinct correct cells (§9 #2/#3)
+- [x] 1.2 Add/adjust unit tests asserting the entrance and exit tags land on the correct, distinct cells
+- [x] 1.3 Confirm the lossless round-trip path is `AreaSerializer.Serialize/Deserialize`; add a test asserting `GeneratedWorld.Serialize()`/`Area.ToString()` are debug labels that MUST NOT be fed to the store seam (documents the D5 trap)
+- [x] 1.4 Add a runnable example (CLI `usecase`/snippet) demonstrating the corrected POIs and the lossless round-trip
 
 ## 2. Façade contract types (region-facade)
 

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,27 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Auto-injected into every future change's artifact instructions.
+rules:
+  specs:
+    - >-
+      docs/INTEGRATION.md is the single, living, always-latest integration
+      guide covering every scenario in docs/SCENARIOS.md. If a change adds,
+      removes, or modifies public API, or changes a scenario's support status,
+      it MUST update docs/INTEGRATION.md and re-mark the affected
+      docs/SCENARIOS.md rows within the same change — never in a follow-up.
+  tasks:
+    - >-
+      If this change alters the public contract (adds/removes/modifies public
+      API) or changes a scenario's support status, include explicit tasks to
+      update docs/INTEGRATION.md (the living integration guide) and to re-mark
+      the affected docs/SCENARIOS.md rows.

--- a/src/PlayersWorlds.Maps.csproj
+++ b/src/PlayersWorlds.Maps.csproj
@@ -14,9 +14,35 @@
     <AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
 
+  <!-- NuGet package metadata. Version is supplied by CI from the git tag
+       (-p:Version=X.Y.Z); VersionPrefix below is only the local/dev fallback.
+       No PackageReference here keeps the published dependency graph empty. -->
+  <PropertyGroup>
+    <PackageId>PlayersWorlds.Maps</PackageId>
+    <VersionPrefix>0.0.0</VersionPrefix>
+    <Authors>Player's Worlds, Inc.</Authors>
+    <Description>Procedural maze/dungeon map-generation library: corridors, rooms, halls, caves, and impassable zones for 2D/3D games. BCL-only (no dependencies) so it drops cleanly into a Godot (net8.0) project. Exposes a region façade (PlayersWorlds.Maps.World) a game codes against.</Description>
+    <PackageTags>maze;dungeon;procedural-generation;roguelike;gamedev;godot</PackageTags>
+    <PackageProjectUrl>https://github.com/krmrn42/maze-gen</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/krmrn42/maze-gen</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Embed symbols in the DLL: line numbers in consumer stack traces with no
+         separate .snupkg to push. -->
+    <DebugType>embedded</DebugType>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- Tests reach internal members; keep the API surface narrow (see CLAUDE.md). -->
     <InternalsVisibleTo Include="PlayersWorlds.Maps.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The repo README doubles as the NuGet package readme. -->
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/RandomSource.cs
+++ b/src/RandomSource.cs
@@ -47,6 +47,17 @@ namespace PlayersWorlds.Maps {
         }
 
         /// <summary>
+        /// Creates a new RandomSource with an explicit seed, for deterministic,
+        /// reproducible generation (e.g. per-region seeding in the world
+        /// façade, where each region address derives its own seed).
+        /// </summary>
+        /// <param name="seed">The seed to use for random number generation.
+        /// </param>
+        /// <returns>A new, seeded instance of RandomSource.</returns>
+        public static RandomSource FromSeed(int seed) =>
+            new RandomSource(seed);
+
+        /// <summary>
         /// Logs the usage of the random source and returns the Random instance.
         /// </summary>
         /// <param name="refName">The reference name of the method calling this

--- a/src/areas/BasicAreaGenerator.cs
+++ b/src/areas/BasicAreaGenerator.cs
@@ -79,7 +79,6 @@ namespace PlayersWorlds.Maps.Areas {
 
         private Area CreateRandomArea(ICollection<Area> generatedAreas) {
             var type = _randomSource.RandomOf(_areaTypes);
-            var tag = _randomSource.RandomOf(_tags);
             Area area;
             var size = new Vector(
                 _randomSource.Next(_minSize.X, _maxSize.X),
@@ -87,7 +86,10 @@ namespace PlayersWorlds.Maps.Areas {
             var pos = new Vector(
                 _randomSource.Next(0, _targetArea.Size.X - size.X),
                 _randomSource.Next(0, _targetArea.Size.Y - size.Y));
-            area = Area.Create(pos, size, type, tag);
+            // Tags are optional; only assign one when the caller supplied some.
+            area = _tags.Length == 0
+                ? Area.Create(pos, size, type)
+                : Area.Create(pos, size, type, _randomSource.RandomOf(_tags));
             if (IsAValidLayout(generatedAreas, area)) {
                 return area;
             }

--- a/src/maze/post_processing/DijkstraDistance.cs
+++ b/src/maze/post_processing/DijkstraDistance.cs
@@ -141,10 +141,10 @@ namespace PlayersWorlds.Maps.Maze.PostProcessing {
             distances = Find(maze, startingPoint);
             var targetPoint = distances.OrderByDescending(kvp => kvp.Value)
                                        .Select(kvp => kvp.Key).First();
-            maze[startingPoint].X(new IsLongestTrailEndExtension());
+            maze[targetPoint].X(new IsLongestTrailEndExtension());
             var solution = Solve(maze, startingPoint, targetPoint).Value;
             foreach (var cell in solution) {
-                maze[startingPoint].X(new IsLongestTrailExtension());
+                maze[cell].X(new IsLongestTrailExtension());
             }
             return new LongestTrailExtension(solution);
         }

--- a/src/world/Gate.cs
+++ b/src/world/Gate.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace PlayersWorlds.Maps.World {
+    /// <summary>
+    /// An opening on a region's border: the passable cells lying on one border
+    /// face of the region. Gates are the future seam anchors — the cells a
+    /// neighbouring region will stitch onto.
+    /// </summary>
+    /// <remarks>
+    /// A border face is identified N-dimensionally by an axis
+    /// (<see cref="Dimension"/>) and which side of that axis it sits on
+    /// (<see cref="AtFarSide"/>). Phase 0 <i>surfaces</i> the gates a region
+    /// happens to have (the passable cells already on its border); gate-aware
+    /// <i>generation</i> — carving a region so its gates line up with a
+    /// neighbour's — is a later phase behind this same shape.
+    /// </remarks>
+    public readonly struct Gate {
+        private readonly Vector[] _openCells;
+
+        /// <summary>
+        /// The axis of the border face this gate is on (0 = x, 1 = y, …).
+        /// </summary>
+        public int Dimension { get; }
+
+        /// <summary>
+        /// <c>false</c> for the low side of the axis (local coordinate 0),
+        /// <c>true</c> for the high side (local coordinate <c>size - 1</c>).
+        /// </summary>
+        public bool AtFarSide { get; }
+
+        /// <summary>
+        /// The passable region-local cells lying on this border face.
+        /// </summary>
+        public IReadOnlyList<Vector> OpenCells => _openCells;
+
+        internal Gate(int dimension, bool atFarSide, Vector[] openCells) {
+            Dimension = dimension;
+            AtFarSide = atFarSide;
+            _openCells = openCells;
+        }
+    }
+}

--- a/src/world/IRegionStore.cs
+++ b/src/world/IRegionStore.cs
@@ -1,0 +1,47 @@
+namespace PlayersWorlds.Maps.World {
+    /// <summary>
+    /// The persistence seam the game implements so the engine generates a
+    /// region exactly once and thereafter reloads it. The engine owns the
+    /// (lossless) serialization; the store only persists and retrieves opaque
+    /// serialized blobs keyed by <see cref="RegionAddress"/> — a plain
+    /// key/value or blob store on the game side.
+    /// </summary>
+    public interface IRegionStore {
+        /// <summary>
+        /// Tries to load a previously saved region.
+        /// </summary>
+        /// <param name="address">The region address.</param>
+        /// <param name="serializedRegion">The serialized region blob if found;
+        /// otherwise <c>null</c>.</param>
+        /// <returns><c>true</c> if a stored region was found; otherwise
+        /// <c>false</c>.</returns>
+        bool TryLoad(RegionAddress address, out string serializedRegion);
+
+        /// <summary>
+        /// Persists a region blob for later retrieval by
+        /// <see cref="TryLoad"/>.
+        /// </summary>
+        /// <param name="address">The region address.</param>
+        /// <param name="serializedRegion">The serialized region blob.</param>
+        void Save(RegionAddress address, string serializedRegion);
+    }
+
+    /// <summary>
+    /// A store that never has anything (always a miss) and never saves — so
+    /// <see cref="World.GetOrCreate"/> regenerates every time and persists
+    /// nothing. The default for a game that regenerates its single region at
+    /// startup (mazzzze v1).
+    /// </summary>
+    public sealed class NullRegionStore : IRegionStore {
+        /// <inheritdoc/>
+        public bool TryLoad(RegionAddress address, out string serializedRegion) {
+            serializedRegion = null;
+            return false;
+        }
+
+        /// <inheritdoc/>
+        public void Save(RegionAddress address, string serializedRegion) {
+            // Intentionally does nothing: this store never persists.
+        }
+    }
+}

--- a/src/world/Poi.cs
+++ b/src/world/Poi.cs
@@ -1,0 +1,49 @@
+namespace PlayersWorlds.Maps.World {
+    /// <summary>
+    /// The kind of a <see cref="Poi"/> (point of interest).
+    /// </summary>
+    public enum PoiKind {
+        /// <summary>
+        /// The region entrance — one end of the region's longest path. A good
+        /// default player spawn.
+        /// </summary>
+        Entrance,
+        /// <summary>
+        /// The region exit — the other end of the region's longest path. A good
+        /// default level goal.
+        /// </summary>
+        Exit,
+        /// <summary>
+        /// A dead-end cell — a corridor tip with a single passage. Useful for
+        /// placing loot, secrets, or encounters.
+        /// </summary>
+        DeadEnd,
+    }
+
+    /// <summary>
+    /// A point of interest inside a region, addressed by a region-local
+    /// (Block) cell coordinate.
+    /// </summary>
+    /// <remarks>
+    /// POIs are computed on the underlying maze and bridged into Block
+    /// coordinates by the façade, so a consumer can place content directly on
+    /// the same cell coordinates it renders (see
+    /// <see cref="RegionView.CellAt"/>).
+    /// </remarks>
+    public readonly struct Poi {
+        /// <summary>
+        /// What this point of interest represents.
+        /// </summary>
+        public PoiKind Kind { get; }
+
+        /// <summary>
+        /// The region-local (Block) cell coordinate of this point of interest.
+        /// </summary>
+        public Vector Local { get; }
+
+        internal Poi(PoiKind kind, Vector local) {
+            Kind = kind;
+            Local = local;
+        }
+    }
+}

--- a/src/world/RegionAddress.cs
+++ b/src/world/RegionAddress.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+
+namespace PlayersWorlds.Maps.World {
+    /// <summary>
+    /// A region's place on the region lattice: an N-dimensional integer
+    /// coordinate naming which region this is, independent of the region's
+    /// internal cell coordinates.
+    /// </summary>
+    /// <remarks>
+    /// Stable identity of a game object is the pair
+    /// <c>(RegionAddress, localCell)</c>. World (absolute) cell coordinates are
+    /// <i>derived</i> via <see cref="ToWorld"/> / <see cref="FromWorld"/> so a
+    /// region can unload and reload without the game re-keying anything — the
+    /// endless-world requirement. The address space is unbounded; there is no
+    /// fixed grid.
+    /// </remarks>
+    public readonly struct RegionAddress : IEquatable<RegionAddress> {
+        private readonly Vector _value;
+
+        /// <summary>
+        /// The lattice coordinate of this region.
+        /// </summary>
+        public Vector Value => _value;
+
+        /// <summary>
+        /// Number of dimensions of the region lattice.
+        /// </summary>
+        public int Dimensions => _value.Dimensions;
+
+        /// <summary>
+        /// Creates a region address from a lattice coordinate.
+        /// </summary>
+        /// <param name="value">The lattice coordinate (must be non-empty).
+        /// </param>
+        public RegionAddress(Vector value) {
+            if (value.IsEmpty) {
+                throw new ArgumentException(
+                    "RegionAddress requires a non-empty coordinate.",
+                    nameof(value));
+            }
+            _value = value;
+        }
+
+        /// <summary>
+        /// Maps a region-local cell coordinate to an absolute world cell
+        /// coordinate, assuming a uniform lattice pitch of
+        /// <paramref name="regionSize"/> (the region's block size).
+        /// </summary>
+        /// <param name="regionSize">The block size of a region (the lattice
+        /// pitch).</param>
+        /// <param name="local">A region-local cell coordinate.</param>
+        /// <returns>The absolute world cell coordinate.</returns>
+        public Vector ToWorld(Vector regionSize, Vector local) {
+            var address = _value;
+            if (regionSize.Dimensions != address.Dimensions ||
+                local.Dimensions != address.Dimensions) {
+                throw new ArgumentException(
+                    "Region size, local coordinate, and address must share " +
+                    "the same number of dimensions.");
+            }
+            return new Vector(Enumerable.Range(0, address.Dimensions)
+                .Select(i => address.Value[i] * regionSize.Value[i] +
+                             local.Value[i]));
+        }
+
+        /// <summary>
+        /// Splits an absolute world cell coordinate into the region that owns
+        /// it and the region-local coordinate within it, assuming a uniform
+        /// lattice pitch of <paramref name="regionSize"/>.
+        /// </summary>
+        /// <param name="world">An absolute world cell coordinate.</param>
+        /// <param name="regionSize">The block size of a region (the lattice
+        /// pitch).</param>
+        /// <returns>The owning region address and the local coordinate, such
+        /// that <c>address.ToWorld(regionSize, local) == world</c>.</returns>
+        public static (RegionAddress Address, Vector Local) FromWorld(
+            Vector world, Vector regionSize) {
+            if (world.Dimensions != regionSize.Dimensions) {
+                throw new ArgumentException(
+                    "World coordinate and region size must share the same " +
+                    "number of dimensions.");
+            }
+            var address = new int[world.Dimensions];
+            var local = new int[world.Dimensions];
+            for (var i = 0; i < world.Dimensions; i++) {
+                var size = regionSize.Value[i];
+                // Floored division so negative world coordinates map to the
+                // region below/left with a non-negative local remainder.
+                var a = (int)Math.Floor((double)world.Value[i] / size);
+                address[i] = a;
+                local[i] = world.Value[i] - a * size;
+            }
+            return (new RegionAddress(new Vector(address)), new Vector(local));
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(RegionAddress other) => _value == other._value;
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) =>
+            obj is RegionAddress other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => _value.GetHashCode();
+
+        /// <summary>Equality operator.</summary>
+        public static bool operator ==(RegionAddress one, RegionAddress other) =>
+            one.Equals(other);
+
+        /// <summary>Inequality operator.</summary>
+        public static bool operator !=(RegionAddress one, RegionAddress other) =>
+            !one.Equals(other);
+
+        /// <inheritdoc/>
+        public override string ToString() => $"Region[{_value}]";
+    }
+}

--- a/src/world/RegionAlgorithm.cs
+++ b/src/world/RegionAlgorithm.cs
@@ -1,0 +1,99 @@
+using System;
+using PlayersWorlds.Maps.Maze;
+
+namespace PlayersWorlds.Maps.World {
+    /// <summary>
+    /// Selects the generation algorithm for a region. The blessed built-ins are
+    /// discoverable as static members; a game can plug in its own algorithm via
+    /// <see cref="Custom{T}"/> without the façade having to enumerate it — a
+    /// closed set for discoverability, open for growth.
+    /// </summary>
+    /// <remarks>
+    /// Algorithms are largely interchangeable — some bias toward winding mazes,
+    /// others toward straighter corridors — so a <see cref="RegionRecipe"/>
+    /// picks a sensible default per intent and you override it here only when
+    /// you want a specific character.
+    /// </remarks>
+    public readonly struct RegionAlgorithm : IEquatable<RegionAlgorithm> {
+        private readonly Type _generatorType;
+
+        internal Type GeneratorType => _generatorType;
+
+        private RegionAlgorithm(Type generatorType) {
+            _generatorType = generatorType;
+        }
+
+        /// <summary>Recursive backtracker — long, winding corridors (default).
+        /// </summary>
+        public static RegionAlgorithm RecursiveBacktracker =>
+            new RegionAlgorithm(GeneratorOptions.Algorithms.RecursiveBacktracker);
+
+        /// <summary>Aldous-Broder — uniform, unbiased spanning tree.</summary>
+        public static RegionAlgorithm AldousBroder =>
+            new RegionAlgorithm(GeneratorOptions.Algorithms.AldousBroder);
+
+        /// <summary>Hunt-and-kill — winding with fewer long dead ends.</summary>
+        public static RegionAlgorithm HuntAndKill =>
+            new RegionAlgorithm(GeneratorOptions.Algorithms.HuntAndKill);
+
+        /// <summary>Wilson's — uniform, unbiased spanning tree.</summary>
+        public static RegionAlgorithm Wilsons =>
+            new RegionAlgorithm(GeneratorOptions.Algorithms.Wilsons);
+
+        /// <summary>Sidewinder — horizontal bias, corridor-like.</summary>
+        public static RegionAlgorithm Sidewinder =>
+            new RegionAlgorithm(GeneratorOptions.Algorithms.Sidewinder);
+
+        /// <summary>Binary tree — strong diagonal bias, very open.</summary>
+        public static RegionAlgorithm BinaryTree =>
+            new RegionAlgorithm(GeneratorOptions.Algorithms.BinaryTree);
+
+        /// <summary>
+        /// Uses a custom generator. <typeparamref name="T"/> must derive from
+        /// <see cref="MazeGenerator"/> and have a parameterless constructor.
+        /// </summary>
+        /// <typeparam name="T">A custom <see cref="MazeGenerator"/>.</typeparam>
+        public static RegionAlgorithm Custom<T>() where T : MazeGenerator =>
+            Custom(typeof(T));
+
+        /// <summary>
+        /// Uses a custom generator type. Must derive from
+        /// <see cref="MazeGenerator"/> and have a parameterless constructor.
+        /// </summary>
+        /// <param name="generatorType">A <see cref="MazeGenerator"/> subtype.
+        /// </param>
+        public static RegionAlgorithm Custom(Type generatorType) {
+            if (generatorType == null) {
+                throw new ArgumentNullException(nameof(generatorType));
+            }
+            if (!typeof(MazeGenerator).IsAssignableFrom(generatorType) ||
+                generatorType.IsAbstract) {
+                throw new ArgumentException(
+                    $"{generatorType.FullName} must be a concrete subtype of " +
+                    nameof(MazeGenerator) + ".", nameof(generatorType));
+            }
+            if (generatorType.GetConstructor(Type.EmptyTypes) == null) {
+                throw new ArgumentException(
+                    $"{generatorType.FullName} must have a parameterless " +
+                    "constructor.", nameof(generatorType));
+            }
+            return new RegionAlgorithm(generatorType);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(RegionAlgorithm other) =>
+            _generatorType == other._generatorType;
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) =>
+            obj is RegionAlgorithm other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() =>
+            _generatorType?.GetHashCode() ?? 0;
+
+        /// <inheritdoc/>
+        public override string ToString() =>
+            _generatorType?.Name ?? "<default>";
+    }
+}

--- a/src/world/RegionCell.cs
+++ b/src/world/RegionCell.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using PlayersWorlds.Maps.Areas;
+
+namespace PlayersWorlds.Maps.World {
+    /// <summary>
+    /// The read-only payload of a single region cell, in Block style (walls
+    /// occupy their own cells). This is a value snapshot: no <see cref="Area"/>
+    /// or <see cref="Cell"/> object is exposed through it.
+    /// </summary>
+    /// <remarks>
+    /// In the current Block output passability is carried by cell
+    /// <see cref="Tags"/> (a floor cell is tagged as a trail; a wall cell is
+    /// tagged as a wall), which is why <see cref="IsPassable"/> is the primary
+    /// signal a renderer needs. <see cref="Type"/> is surfaced for forward
+    /// compatibility; today the Block conversion reports
+    /// <see cref="AreaType.Environment"/> uniformly, and per-cell room/cave
+    /// typing is a later-phase enhancement behind this same surface.
+    /// </remarks>
+    public readonly struct RegionCell {
+        private readonly string[] _tags;
+
+        /// <summary>
+        /// Whether the player can occupy this cell (floor) as opposed to it
+        /// being a wall.
+        /// </summary>
+        public bool IsPassable { get; }
+
+        /// <summary>
+        /// The area type this cell belongs to.
+        /// </summary>
+        public AreaType Type { get; }
+
+        /// <summary>
+        /// The cell's tags, usable by the game engine to pick tiles, styles, or
+        /// behaviours.
+        /// </summary>
+        public IReadOnlyList<string> Tags => _tags ?? Array.Empty<string>();
+
+        internal RegionCell(bool isPassable, AreaType type, string[] tags) {
+            IsPassable = isPassable;
+            Type = type;
+            _tags = tags;
+        }
+    }
+}

--- a/src/world/RegionRecipe.cs
+++ b/src/world/RegionRecipe.cs
@@ -97,9 +97,16 @@ namespace PlayersWorlds.Maps.World {
         /// Returns a copy that also auto-places <paramref name="count"/> rooms
         /// of <paramref name="kind"/>, each sized between
         /// <paramref name="minSize"/> and <paramref name="maxSize"/> (in world
-        /// Block cells), tagged with <paramref name="tags"/>. Call it more than
-        /// once to mix kinds. Rooms are placed best-effort without overlapping.
+        /// Block cells — the same unit as <c>regionSize</c>), tagged with
+        /// <paramref name="tags"/>. Call it more than once to mix kinds. Rooms
+        /// are placed best-effort without overlapping.
         /// </summary>
+        /// <remarks>
+        /// Rooms snap to the underlying maze grid (pitch = cell + wall, i.e. 2
+        /// world cells for square 1×1 cells), so a room smaller than ~3 world
+        /// cells collapses to a single corridor cell and is not visible as a
+        /// room. Use ≥3 (and a footprint with room to place them).
+        /// </remarks>
         /// <param name="count">How many rooms of this kind to place.</param>
         /// <param name="minSize">Minimum room size, in world cells.</param>
         /// <param name="maxSize">Maximum room size, in world cells.</param>

--- a/src/world/RegionRecipe.cs
+++ b/src/world/RegionRecipe.cs
@@ -1,23 +1,26 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PlayersWorlds.Maps.World {
     /// <summary>
     /// Describes <i>what fills a region's footprint</i> — the algorithm, how
-    /// densely it fills, and the cell shape. A recipe is the region's content;
-    /// <see cref="World"/> supplies the footprint (<c>regionSize</c>) and the
-    /// default recipe, and each <see cref="World.GetOrCreate"/> call may pass
-    /// its own recipe so different regions can be different kinds.
+    /// densely it fills, the cell shape, and any rooms. A recipe is the region's
+    /// content; <see cref="World"/> supplies the footprint (<c>regionSize</c>)
+    /// and the default recipe, and each <see cref="World.GetOrCreate"/> call may
+    /// pass its own recipe so different regions can be different kinds.
     /// </summary>
     /// <remarks>
-    /// Recipes are immutable: start from an intent preset
-    /// (<see cref="Maze"/>, <see cref="Corridors"/>) and
-    /// layer overrides with the <c>With…</c> methods, each returning a new
-    /// recipe. Cell shape defaults to <b>square</b> 1×1. (Room support —
-    /// <c>Dungeon</c>/<c>Caverns</c> presets and <c>WithRooms</c> — is added
-    /// next, behind this same type.)
+    /// Recipes are immutable: start from an intent preset (<see cref="Maze"/>,
+    /// <see cref="Corridors"/>, <see cref="Dungeon"/>, <see cref="Caverns"/>)
+    /// and layer overrides with the <c>With…</c> methods, each returning a new
+    /// recipe. Cell shape defaults to <b>square</b> 1×1.
     /// </remarks>
     public sealed class RegionRecipe {
         private static readonly Vector Square1 = new Vector(1, 1);
+        private static readonly RoomRequest[] NoRooms = new RoomRequest[0];
+
+        private readonly RoomRequest[] _rooms;
 
         /// <summary>The generation algorithm.</summary>
         public RegionAlgorithm Algorithm { get; }
@@ -34,33 +37,51 @@ namespace PlayersWorlds.Maps.World {
         /// thickness).</summary>
         public Vector WallSize { get; }
 
+        internal IReadOnlyList<RoomRequest> Rooms => _rooms;
+
         private RegionRecipe(RegionAlgorithm algorithm, double fill,
-                             Vector cellSize, Vector wallSize) {
+                             Vector cellSize, Vector wallSize,
+                             RoomRequest[] rooms) {
             Algorithm = algorithm;
             Fill = fill;
             CellSize = cellSize;
             WallSize = wallSize;
+            _rooms = rooms;
         }
 
         /// <summary>A classic perfect maze — long winding corridors, fully
-        /// connected.</summary>
+        /// connected, no rooms.</summary>
         public static RegionRecipe Maze =>
             new RegionRecipe(RegionAlgorithm.RecursiveBacktracker, 1.0,
-                             Square1, Square1);
+                             Square1, Square1, NoRooms);
 
-        /// <summary>Straighter, corridor-biased passages.</summary>
+        /// <summary>Straighter, corridor-biased passages, no rooms.</summary>
         public static RegionRecipe Corridors =>
-            new RegionRecipe(RegionAlgorithm.Sidewinder, 1.0, Square1, Square1);
+            new RegionRecipe(RegionAlgorithm.Sidewinder, 1.0, Square1, Square1,
+                             NoRooms);
+
+        /// <summary>Corridors linking several walled halls.</summary>
+        public static RegionRecipe Dungeon =>
+            Maze.WithRooms(6, new Vector(6, 6), new Vector(10, 10),
+                           RoomKind.Hall);
+
+        /// <summary>Organic caverns — larger, less regular open rooms.
+        /// </summary>
+        public static RegionRecipe Caverns =>
+            new RegionRecipe(RegionAlgorithm.AldousBroder, 1.0, Square1, Square1,
+                             NoRooms)
+                .WithRooms(7, new Vector(5, 5), new Vector(11, 11),
+                           RoomKind.Cave);
 
         /// <summary>Returns a copy with a different algorithm.</summary>
         public RegionRecipe WithAlgorithm(RegionAlgorithm algorithm) =>
-            new RegionRecipe(algorithm, Fill, CellSize, WallSize);
+            new RegionRecipe(algorithm, Fill, CellSize, WallSize, _rooms);
 
         /// <summary>Returns a copy with a different fill density (clamped to
         /// 0..1).</summary>
         public RegionRecipe WithFill(double fill) =>
             new RegionRecipe(Algorithm, Math.Max(0.0, Math.Min(1.0, fill)),
-                             CellSize, WallSize);
+                             CellSize, WallSize, _rooms);
 
         /// <summary>Returns a copy with square cells of the given side (walls
         /// and corridors equal — the usual game choice).</summary>
@@ -70,6 +91,32 @@ namespace PlayersWorlds.Maps.World {
         /// <summary>Returns a copy with explicit corridor and wall cell sizes
         /// (non-square deliberately stretches the region).</summary>
         public RegionRecipe WithCells(Vector cellSize, Vector wallSize) =>
-            new RegionRecipe(Algorithm, Fill, cellSize, wallSize);
+            new RegionRecipe(Algorithm, Fill, cellSize, wallSize, _rooms);
+
+        /// <summary>
+        /// Returns a copy that also auto-places <paramref name="count"/> rooms
+        /// of <paramref name="kind"/>, each sized between
+        /// <paramref name="minSize"/> and <paramref name="maxSize"/> (in world
+        /// Block cells), tagged with <paramref name="tags"/>. Call it more than
+        /// once to mix kinds. Rooms are placed best-effort without overlapping.
+        /// </summary>
+        /// <param name="count">How many rooms of this kind to place.</param>
+        /// <param name="minSize">Minimum room size, in world cells.</param>
+        /// <param name="maxSize">Maximum room size, in world cells.</param>
+        /// <param name="kind">The room's structural kind.</param>
+        /// <param name="tags">Open-ended semantic tags (e.g. "armory").</param>
+        public RegionRecipe WithRooms(int count, Vector minSize, Vector maxSize,
+                                      RoomKind kind = RoomKind.Hall,
+                                      params string[] tags) {
+            if (count < 0) {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+            minSize.ThrowIfNotAValidSize(nameof(minSize));
+            maxSize.ThrowIfNotAValidSize(nameof(maxSize));
+            var request = new RoomRequest(count, minSize, maxSize, kind,
+                tags ?? new string[0]);
+            return new RegionRecipe(Algorithm, Fill, CellSize, WallSize,
+                _rooms.Concat(new[] { request }).ToArray());
+        }
     }
 }

--- a/src/world/RegionRecipe.cs
+++ b/src/world/RegionRecipe.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace PlayersWorlds.Maps.World {
+    /// <summary>
+    /// Describes <i>what fills a region's footprint</i> — the algorithm, how
+    /// densely it fills, and the cell shape. A recipe is the region's content;
+    /// <see cref="World"/> supplies the footprint (<c>regionSize</c>) and the
+    /// default recipe, and each <see cref="World.GetOrCreate"/> call may pass
+    /// its own recipe so different regions can be different kinds.
+    /// </summary>
+    /// <remarks>
+    /// Recipes are immutable: start from an intent preset
+    /// (<see cref="Maze"/>, <see cref="Corridors"/>) and
+    /// layer overrides with the <c>With…</c> methods, each returning a new
+    /// recipe. Cell shape defaults to <b>square</b> 1×1. (Room support —
+    /// <c>Dungeon</c>/<c>Caverns</c> presets and <c>WithRooms</c> — is added
+    /// next, behind this same type.)
+    /// </remarks>
+    public sealed class RegionRecipe {
+        private static readonly Vector Square1 = new Vector(1, 1);
+
+        /// <summary>The generation algorithm.</summary>
+        public RegionAlgorithm Algorithm { get; }
+
+        /// <summary>How densely the algorithm fills the footprint, 0..1
+        /// (1 = fully connected).</summary>
+        public double Fill { get; }
+
+        /// <summary>The size, in Block cells, of each cell's walkable interior
+        /// (corridor width).</summary>
+        public Vector CellSize { get; }
+
+        /// <summary>The size, in Block cells, of the walls between cells (wall
+        /// thickness).</summary>
+        public Vector WallSize { get; }
+
+        private RegionRecipe(RegionAlgorithm algorithm, double fill,
+                             Vector cellSize, Vector wallSize) {
+            Algorithm = algorithm;
+            Fill = fill;
+            CellSize = cellSize;
+            WallSize = wallSize;
+        }
+
+        /// <summary>A classic perfect maze — long winding corridors, fully
+        /// connected.</summary>
+        public static RegionRecipe Maze =>
+            new RegionRecipe(RegionAlgorithm.RecursiveBacktracker, 1.0,
+                             Square1, Square1);
+
+        /// <summary>Straighter, corridor-biased passages.</summary>
+        public static RegionRecipe Corridors =>
+            new RegionRecipe(RegionAlgorithm.Sidewinder, 1.0, Square1, Square1);
+
+        /// <summary>Returns a copy with a different algorithm.</summary>
+        public RegionRecipe WithAlgorithm(RegionAlgorithm algorithm) =>
+            new RegionRecipe(algorithm, Fill, CellSize, WallSize);
+
+        /// <summary>Returns a copy with a different fill density (clamped to
+        /// 0..1).</summary>
+        public RegionRecipe WithFill(double fill) =>
+            new RegionRecipe(Algorithm, Math.Max(0.0, Math.Min(1.0, fill)),
+                             CellSize, WallSize);
+
+        /// <summary>Returns a copy with square cells of the given side (walls
+        /// and corridors equal — the usual game choice).</summary>
+        public RegionRecipe WithCells(int square) =>
+            WithCells(new Vector(square, square), new Vector(square, square));
+
+        /// <summary>Returns a copy with explicit corridor and wall cell sizes
+        /// (non-square deliberately stretches the region).</summary>
+        public RegionRecipe WithCells(Vector cellSize, Vector wallSize) =>
+            new RegionRecipe(Algorithm, Fill, cellSize, wallSize);
+    }
+}

--- a/src/world/RegionTags.cs
+++ b/src/world/RegionTags.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace PlayersWorlds.Maps.World {
+    /// <summary>
+    /// Block cell tags the façade bakes onto region cells so that a region is
+    /// fully self-describing — its points of interest survive a lossless
+    /// <see cref="Serializer.AreaSerializer"/> round-trip as cell tags, with no
+    /// separate side-channel and no need to keep the underlying maze around.
+    /// </summary>
+    internal static class RegionTags {
+        internal const string Entrance = "REGION_ENTRANCE";
+        internal const string Exit = "REGION_EXIT";
+        internal const string DeadEnd = "REGION_DEADEND";
+
+        internal static string For(PoiKind kind) => kind switch {
+            PoiKind.Entrance => Entrance,
+            PoiKind.Exit => Exit,
+            PoiKind.DeadEnd => DeadEnd,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+    }
+}

--- a/src/world/RegionView.cs
+++ b/src/world/RegionView.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Linq;
+using PlayersWorlds.Maps.Areas;
+
+namespace PlayersWorlds.Maps.World {
+    /// <summary>
+    /// A read-only view of a single generated region: Block-style cells, its
+    /// place on the region lattice, its points of interest, and its border
+    /// gates. This is the frozen library contract a game codes against — no
+    /// <see cref="Area"/>, <see cref="Cell"/>, or other internal machinery is
+    /// reachable through it.
+    /// </summary>
+    public sealed class RegionView {
+        private readonly Area _region;
+        private readonly Poi[] _pois;
+        private readonly Gate[] _gates;
+
+        /// <summary>
+        /// This region's place on the region lattice.
+        /// </summary>
+        public RegionAddress Address { get; }
+
+        /// <summary>
+        /// The region's size in Block cells.
+        /// </summary>
+        public Vector Size => _region.Size;
+
+        /// <summary>
+        /// The region's points of interest (entrance/exit and dead-ends), in
+        /// region-local (Block) coordinates.
+        /// </summary>
+        public IReadOnlyList<Poi> Pois => _pois;
+
+        /// <summary>
+        /// The openings on this region's borders (the future seam anchors).
+        /// </summary>
+        public IReadOnlyList<Gate> Gates => _gates;
+
+        /// <summary>
+        /// Whether <paramref name="local"/> is a valid cell coordinate within
+        /// this region.
+        /// </summary>
+        public bool Contains(Vector local) => _region.Grid.Contains(local);
+
+        /// <summary>
+        /// The cell payload at a region-local coordinate.
+        /// </summary>
+        /// <param name="local">A region-local (Block) cell coordinate.</param>
+        /// <returns>The read-only <see cref="RegionCell"/> at that coordinate.
+        /// </returns>
+        /// <exception cref="System.IndexOutOfRangeException">The coordinate is
+        /// outside the region bounds.</exception>
+        public RegionCell CellAt(Vector local) {
+            var cell = _region[local];
+            var tags = cell.Tags.Select(t => t.ToString()).Distinct().ToArray();
+            return new RegionCell(IsPassable(cell), cell.AreaType, tags);
+        }
+
+        /// <summary>
+        /// Maps a region-local coordinate to its absolute world coordinate.
+        /// </summary>
+        public Vector ToWorld(Vector local) => Address.ToWorld(Size, local);
+
+        internal RegionView(RegionAddress address, Area region) {
+            Address = address;
+            _region = region;
+            _pois = ComputePois(region);
+            _gates = ComputeGates(region);
+        }
+
+        private static bool IsPassable(Cell cell) =>
+            cell.Tags.Any(t => t.Equals(Cell.CellTag.MazeTrail));
+
+        private static Poi[] ComputePois(Area region) {
+            var pois = new List<Poi>();
+            foreach (var v in region.Grid) {
+                foreach (var tag in region[v].Tags) {
+                    if (tag.Equals(RegionTags.Entrance)) {
+                        pois.Add(new Poi(PoiKind.Entrance, v));
+                    } else if (tag.Equals(RegionTags.Exit)) {
+                        pois.Add(new Poi(PoiKind.Exit, v));
+                    } else if (tag.Equals(RegionTags.DeadEnd)) {
+                        pois.Add(new Poi(PoiKind.DeadEnd, v));
+                    }
+                }
+            }
+            return pois.ToArray();
+        }
+
+        private static Gate[] ComputeGates(Area region) {
+            var size = region.Size;
+            var gates = new List<Gate>();
+            for (var d = 0; d < size.Dimensions; d++) {
+                foreach (var atFarSide in new[] { false, true }) {
+                    var border = atFarSide ? size.Value[d] - 1 : 0;
+                    var open = region.Grid
+                        .Where(v => v.Value[d] == border)
+                        .Where(v => IsPassable(region[v]))
+                        .ToArray();
+                    if (open.Length > 0) {
+                        gates.Add(new Gate(d, atFarSide, open));
+                    }
+                }
+            }
+            return gates.ToArray();
+        }
+    }
+}

--- a/src/world/RoomKind.cs
+++ b/src/world/RoomKind.cs
@@ -1,0 +1,20 @@
+namespace PlayersWorlds.Maps.World {
+    /// <summary>
+    /// The structural kind of a room placed in a region — the small, stable set
+    /// of area types maze-gen supports as rooms. What a room is <i>for</i>
+    /// (armory, boss, shrine, …) is an open-ended concern expressed with tags,
+    /// not this enum.
+    /// </summary>
+    public enum RoomKind {
+        /// <summary>A walled room with controlled entrances (maze
+        /// <c>Hall</c>) — walkable open space carved into the maze.</summary>
+        Hall,
+        /// <summary>An organic room with any number of entrances (maze
+        /// <c>Cave</c>) — walkable, less regular than a hall.</summary>
+        Cave,
+        /// <summary>An impassable obstacle — rock, water, a pit (maze
+        /// <c>Fill</c>). The player cannot enter it; the maze routes
+        /// around it.</summary>
+        Blocked,
+    }
+}

--- a/src/world/RoomRequest.cs
+++ b/src/world/RoomRequest.cs
@@ -1,0 +1,25 @@
+namespace PlayersWorlds.Maps.World {
+    /// <summary>
+    /// A request to auto-place <see cref="Count"/> rooms of a kind and size
+    /// range. Internal — a <see cref="RegionRecipe"/> accumulates these and
+    /// <see cref="World"/> distributes them across the region footprint.
+    /// Sizes are in world (Block) cells; the generator snaps them to the
+    /// underlying maze grid.
+    /// </summary>
+    internal sealed class RoomRequest {
+        public int Count { get; }
+        public Vector MinSize { get; }
+        public Vector MaxSize { get; }
+        public RoomKind Kind { get; }
+        public string[] Tags { get; }
+
+        public RoomRequest(int count, Vector minSize, Vector maxSize,
+                           RoomKind kind, string[] tags) {
+            Count = count;
+            MinSize = minSize;
+            MaxSize = maxSize;
+            Kind = kind;
+            Tags = tags;
+        }
+    }
+}

--- a/src/world/World.cs
+++ b/src/world/World.cs
@@ -8,33 +8,31 @@ using static PlayersWorlds.Maps.Maze.Maze2DRenderer;
 
 namespace PlayersWorlds.Maps.World {
     /// <summary>
-    /// The entry point of the region contract: a synchronous factory that hands
-    /// a game one generated <see cref="RegionView"/> per <see cref="RegionAddress"/>,
-    /// generating it once and thereafter reloading it from the game's
-    /// <see cref="IRegionStore"/>.
+    /// A persistent, seeded space of regions — created once (a game-start
+    /// event) and then asked for one region at a time as the player moves (a
+    /// positioning / environment-loading event).
     /// </summary>
     /// <remarks>
-    /// The call blocks — maze generation is bounded but can take a few
-    /// milliseconds to tens of milliseconds — and it is the game's job to decide
-    /// <i>when</i> to call it and off which thread. There is no "endless" call:
-    /// each call produces one bounded region; the endless world emerges from the
-    /// game calling repeatedly for the addresses it needs. Generation is
-    /// deterministic: the same world seed and address always produce the same
-    /// region.
+    /// The world holds what every region shares and inherits: the seed, the
+    /// store, the region footprint (<c>regionSize</c>), and a default recipe.
+    /// Each <see cref="GetOrCreate"/> may pass its own <see cref="RegionRecipe"/>
+    /// so different regions can be different kinds. Regions tile a <b>uniform
+    /// lattice</b>: every region is <c>regionSize</c> Block cells, which is
+    /// exactly what <see cref="RegionView.Size"/> reports and the pitch
+    /// <see cref="RegionAddress.ToWorld"/> uses.
+    ///
+    /// The call blocks (bounded — a few to tens of ms); the game decides when to
+    /// call it and off which thread. Generation is deterministic: same world
+    /// seed + address always produce the same region.
     /// </remarks>
     public sealed class World {
         private readonly IRegionStore _store;
         private readonly int _worldSeed;
-        private readonly Vector _regionMazeSize;
-        private readonly Maze2DRendererOptions _renderOptions;
-        private readonly Type _algorithm =
-            GeneratorOptions.Algorithms.RecursiveBacktracker;
-        private readonly GeneratorOptions.MazeFillFactor _fillFactor =
-            GeneratorOptions.MazeFillFactor.Full;
+        private readonly Vector _regionSize;
+        private readonly RegionRecipe _defaultRecipe;
 
         /// <summary>
-        /// Creates a world façade with <b>square</b> 1×1 Block cells — the
-        /// correct default for a game whose tiles are square in world space.
+        /// Creates a world.
         /// </summary>
         /// <param name="store">The game's persistence seam. Use a
         /// <see cref="NullRegionStore"/> to always regenerate and persist
@@ -42,53 +40,42 @@ namespace PlayersWorlds.Maps.World {
         /// <param name="worldSeed">The base seed; each region derives its own
         /// seed from this and its address, so regions are independently
         /// reproducible.</param>
-        /// <param name="regionMazeSize">The region size in <i>maze</i> cells
-        /// (before Block expansion). The rendered Block size is larger; read it
-        /// from <see cref="RegionView.Size"/>.</param>
-        public World(IRegionStore store, int worldSeed, Vector regionMazeSize)
-            : this(store, worldSeed, regionMazeSize,
-                   new Vector(1, 1), new Vector(1, 1)) { }
-
-        /// <summary>
-        /// Creates a world façade with explicit Block cell sizing — the client
-        /// owns the cell shape. Non-square sizes stretch the region; a game
-        /// wanting square tiles passes equal, square sizes (the default ctor).
-        /// </summary>
-        /// <param name="store">The game's persistence seam.</param>
-        /// <param name="worldSeed">The base seed for per-region seeding.</param>
-        /// <param name="regionMazeSize">The region size in <i>maze</i> cells.
-        /// </param>
-        /// <param name="cellSize">The size, in Block cells, of each maze cell's
-        /// walkable interior (corridor width). Use <c>(1, 1)</c> for square.
-        /// </param>
-        /// <param name="wallSize">The size, in Block cells, of the walls between
-        /// maze cells (wall thickness). Use <c>(1, 1)</c> for square.</param>
-        public World(IRegionStore store, int worldSeed, Vector regionMazeSize,
-                     Vector cellSize, Vector wallSize) {
+        /// <param name="regionSize">The region's footprint in the world, in
+        /// Block cells — the uniform lattice pitch. This is exactly what
+        /// <see cref="RegionView.Size"/> reports; the number of corridors/rooms
+        /// within it is derived from the recipe's cell sizing.</param>
+        /// <param name="defaultRecipe">What a region is generated as unless a
+        /// <see cref="GetOrCreate"/> call overrides it. Defaults to
+        /// <see cref="RegionRecipe.Maze"/>.</param>
+        public World(IRegionStore store, int worldSeed, Vector regionSize,
+                     RegionRecipe defaultRecipe = null) {
             _store = store ?? throw new ArgumentNullException(nameof(store));
             _worldSeed = worldSeed;
-            regionMazeSize.ThrowIfNotAValidSize(nameof(regionMazeSize));
-            _regionMazeSize = regionMazeSize;
-            cellSize.ThrowIfNotAValidSize(nameof(cellSize));
-            wallSize.ThrowIfNotAValidSize(nameof(wallSize));
-            _renderOptions = Maze2DRendererOptions.RectCells(cellSize, wallSize);
+            regionSize.ThrowIfNotAValidSize(nameof(regionSize));
+            _regionSize = regionSize;
+            _defaultRecipe = defaultRecipe ?? RegionRecipe.Maze;
         }
 
         /// <summary>
         /// Returns the region at <paramref name="address"/>: the stored region
-        /// if the store has one, otherwise a freshly generated region that is
-        /// then saved. Synchronous; no streaming.
+        /// if the store has one, otherwise a freshly generated region (using
+        /// <paramref name="recipe"/>, or the world's default) that is then
+        /// saved. Synchronous; no streaming.
         /// </summary>
-        /// <param name="address">The region's address on the region lattice.
-        /// </param>
+        /// <param name="address">The region's address on the lattice.</param>
+        /// <param name="recipe">The recipe for this region if it must be
+        /// generated. Ignored if the region is already stored (a region's kind
+        /// is fixed when it is first created). Defaults to the world's default
+        /// recipe.</param>
         /// <returns>The region as a read-only <see cref="RegionView"/>.</returns>
-        public RegionView GetOrCreate(RegionAddress address) {
+        public RegionView GetOrCreate(RegionAddress address,
+                                      RegionRecipe recipe = null) {
             if (_store.TryLoad(address, out var serialized) &&
                 !string.IsNullOrEmpty(serialized)) {
                 var loaded = new AreaSerializer().Deserialize(serialized);
                 return new RegionView(address, loaded);
             }
-            var region = Generate(address);
+            var region = Generate(address, recipe ?? _defaultRecipe);
             _store.Save(address, new AreaSerializer().Serialize(region));
             return new RegionView(address, region);
         }
@@ -101,21 +88,25 @@ namespace PlayersWorlds.Maps.World {
             return seed;
         }
 
-        private Area Generate(RegionAddress address) {
+        private Area Generate(RegionAddress address, RegionRecipe recipe) {
             var randomSource = RandomSource.FromSeed(SeedFor(address));
+            var renderOptions =
+                Maze2DRendererOptions.RectCells(recipe.CellSize, recipe.WallSize);
+            var mazeCells =
+                DeriveMazeCells(_regionSize, recipe.CellSize, recipe.WallSize);
             var options = new GeneratorOptions() {
                 RandomSource = randomSource,
-                MazeAlgorithm = _algorithm,
-                FillFactor = _fillFactor,
+                MazeAlgorithm = recipe.Algorithm.GeneratorType,
+                FillFactor = MapFill(recipe.Fill),
             };
             var builder = new GeneratedWorld(randomSource)
-                .AddLayer(AreaType.Maze, _regionMazeSize)
+                .AddLayer(AreaType.Maze, mazeCells)
                 .OfMaze(MazeStructureStyle.Border, options)
                 .MarkLongestPath()
                 .MarkDeadends();
 
-            // Capture the POIs on the Border maze BEFORE ToMap discards the
-            // marker attachments; bridge them into Block coordinates after.
+            // Capture POIs on the Border maze before the Block conversion drops
+            // the marker attachments; bridge them into Block coordinates after.
             var mazeArea = builder.Map();
             var entrance = mazeArea.Grid.Single(v =>
                 mazeArea[v]
@@ -125,25 +116,57 @@ namespace PlayersWorlds.Maps.World {
                     .X<DijkstraDistance.IsLongestTrailEndExtension>() != null);
             var deadEnds = mazeArea.X<DeadEnd.DeadEndsExtension>().DeadEnds;
 
-            builder.ToMap(_renderOptions);
-            var blockMap = builder.Map();
+            // Render into a footprint-sized canvas so RegionView.Size ==
+            // regionSize exactly; any remainder past the maze stays impassable.
+            var blockMap = Area.Create(Vector.Zero(_regionSize.Dimensions),
+                _regionSize, AreaType.Environment);
+            new MazeAreaStyleConverter()
+                .ConvertMazeBorderToBlock(mazeArea, blockMap, renderOptions);
 
-            BakePoi(blockMap, mazeArea, entrance, PoiKind.Entrance);
-            BakePoi(blockMap, mazeArea, exit, PoiKind.Exit);
+            BakePoi(blockMap, mazeArea, entrance, PoiKind.Entrance, renderOptions);
+            BakePoi(blockMap, mazeArea, exit, PoiKind.Exit, renderOptions);
             foreach (var deadEnd in deadEnds
                          .Where(de => de != entrance && de != exit)) {
-                BakePoi(blockMap, mazeArea, deadEnd, PoiKind.DeadEnd);
+                BakePoi(blockMap, mazeArea, deadEnd, PoiKind.DeadEnd,
+                        renderOptions);
             }
             return blockMap;
+        }
+
+        // Largest maze-cell grid whose Block rendering fits inside the region
+        // footprint: footprint = wall + N·(cell + wall) per dimension.
+        private static Vector DeriveMazeCells(Vector footprint, Vector cellSize,
+                                              Vector wallSize) {
+            var cells = new int[footprint.Dimensions];
+            for (var i = 0; i < footprint.Dimensions; i++) {
+                var pitch = cellSize.Value[i] + wallSize.Value[i];
+                var n = (footprint.Value[i] - wallSize.Value[i]) / pitch;
+                if (n < 1) {
+                    throw new ArgumentException(
+                        $"regionSize {footprint} is too small for the cell/wall " +
+                        "sizing; each dimension must fit at least one cell.");
+                }
+                cells[i] = n;
+            }
+            return new Vector(cells);
+        }
+
+        private static GeneratorOptions.MazeFillFactor MapFill(double fill) {
+            if (fill >= 0.95) return GeneratorOptions.MazeFillFactor.Full;
+            if (fill >= 0.825) return GeneratorOptions.MazeFillFactor.NinetyPercent;
+            if (fill >= 0.625) return GeneratorOptions.MazeFillFactor.ThreeQuarters;
+            if (fill >= 0.375) return GeneratorOptions.MazeFillFactor.Half;
+            return GeneratorOptions.MazeFillFactor.Quarter;
         }
 
         // Translates a POI on the Border maze into the Block cell at the centre
         // of that maze cell, and tags it so the POI is a first-class,
         // serializable property of the region.
-        private void BakePoi(Area blockMap, Area mazeArea, Vector mazeCell,
-                             PoiKind kind) {
+        private static void BakePoi(Area blockMap, Area mazeArea, Vector mazeCell,
+                                    PoiKind kind,
+                                    Maze2DRendererOptions renderOptions) {
             var mapping = new CellsMapping(
-                blockMap, mazeCell - mazeArea.Position, _renderOptions);
+                blockMap, mazeCell - mazeArea.Position, renderOptions);
             blockMap[mapping.CenterPosition].Tags.Add(
                 new Cell.CellTag(RegionTags.For(kind)));
         }

--- a/src/world/World.cs
+++ b/src/world/World.cs
@@ -98,9 +98,23 @@ namespace PlayersWorlds.Maps.World {
                 RandomSource = randomSource,
                 MazeAlgorithm = recipe.Algorithm.GeneratorType,
                 FillFactor = MapFill(recipe.Fill),
+                // We place rooms ourselves (below), so the builder carves around
+                // the existing areas rather than distributing its own.
+                AreaGeneration = GeneratorOptions.AreaGenerationMode.Manual,
             };
-            var builder = new GeneratedWorld(randomSource)
-                .AddLayer(AreaType.Maze, mazeCells)
+            var builder =
+                new GeneratedWorld(randomSource).AddLayer(AreaType.Maze, mazeCells);
+            foreach (var room in recipe.Rooms) {
+                var min = ClampToGrid(
+                    ToMazeCells(room.MinSize, recipe.CellSize, recipe.WallSize),
+                    mazeCells);
+                var max = ClampToGrid(
+                    ToMazeCells(room.MaxSize, recipe.CellSize, recipe.WallSize),
+                    mazeCells);
+                builder = builder.WithAreas(new[] { AreaTypeOf(room.Kind) },
+                    room.Tags, room.Count, min, max);
+            }
+            builder = builder
                 .OfMaze(MazeStructureStyle.Border, options)
                 .MarkLongestPath()
                 .MarkDeadends();
@@ -149,6 +163,35 @@ namespace PlayersWorlds.Maps.World {
                 cells[i] = n;
             }
             return new Vector(cells);
+        }
+
+        private static AreaType AreaTypeOf(RoomKind kind) => kind switch {
+            RoomKind.Hall => AreaType.Hall,
+            RoomKind.Cave => AreaType.Cave,
+            RoomKind.Blocked => AreaType.Fill,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+        // Rooms are sized in world (Block) cells; snap each dimension to the
+        // maze grid (one maze cell renders to cell + wall Block cells).
+        private static Vector ToMazeCells(Vector worldSize, Vector cellSize,
+                                          Vector wallSize) {
+            var cells = new int[worldSize.Dimensions];
+            for (var i = 0; i < worldSize.Dimensions; i++) {
+                var pitch = cellSize.Value[i] + wallSize.Value[i];
+                cells[i] = Math.Max(1, worldSize.Value[i] / pitch);
+            }
+            return new Vector(cells);
+        }
+
+        // Keeps a room's maze-cell size within the maze grid so the distributor
+        // never gets an empty placement range for an oversized room.
+        private static Vector ClampToGrid(Vector size, Vector mazeCells) {
+            var clamped = new int[size.Dimensions];
+            for (var i = 0; i < size.Dimensions; i++) {
+                clamped[i] = Math.Max(1, Math.Min(size.Value[i], mazeCells.Value[i]));
+            }
+            return new Vector(clamped);
         }
 
         private static GeneratorOptions.MazeFillFactor MapFill(double fill) {

--- a/src/world/World.cs
+++ b/src/world/World.cs
@@ -173,13 +173,17 @@ namespace PlayersWorlds.Maps.World {
         };
 
         // Rooms are sized in world (Block) cells; snap each dimension to the
-        // maze grid (one maze cell renders to cell + wall Block cells).
+        // maze grid. A hall of N maze cells renders to ~N*(cell+wall) - wall
+        // world cells, so invert that: N ≈ (worldSize + wall) / (cell + wall).
+        // (Plain worldSize/pitch under-sizes — a 3-world-cell room would become
+        // a single maze cell, i.e. an invisible corridor cell.)
         private static Vector ToMazeCells(Vector worldSize, Vector cellSize,
                                           Vector wallSize) {
             var cells = new int[worldSize.Dimensions];
             for (var i = 0; i < worldSize.Dimensions; i++) {
                 var pitch = cellSize.Value[i] + wallSize.Value[i];
-                cells[i] = Math.Max(1, worldSize.Value[i] / pitch);
+                cells[i] = Math.Max(1,
+                    (worldSize.Value[i] + wallSize.Value[i]) / pitch);
             }
             return new Vector(cells);
         }

--- a/src/world/World.cs
+++ b/src/world/World.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Linq;
+using PlayersWorlds.Maps.Areas;
+using PlayersWorlds.Maps.Maze;
+using PlayersWorlds.Maps.Maze.PostProcessing;
+using PlayersWorlds.Maps.Serializer;
+using static PlayersWorlds.Maps.Maze.Maze2DRenderer;
+
+namespace PlayersWorlds.Maps.World {
+    /// <summary>
+    /// The entry point of the region contract: a synchronous factory that hands
+    /// a game one generated <see cref="RegionView"/> per <see cref="RegionAddress"/>,
+    /// generating it once and thereafter reloading it from the game's
+    /// <see cref="IRegionStore"/>.
+    /// </summary>
+    /// <remarks>
+    /// The call blocks — maze generation is bounded but can take a few
+    /// milliseconds to tens of milliseconds — and it is the game's job to decide
+    /// <i>when</i> to call it and off which thread. There is no "endless" call:
+    /// each call produces one bounded region; the endless world emerges from the
+    /// game calling repeatedly for the addresses it needs. Generation is
+    /// deterministic: the same world seed and address always produce the same
+    /// region.
+    /// </remarks>
+    public sealed class World {
+        private readonly IRegionStore _store;
+        private readonly int _worldSeed;
+        private readonly Vector _regionMazeSize;
+        private readonly Maze2DRendererOptions _renderOptions;
+        private readonly Type _algorithm =
+            GeneratorOptions.Algorithms.RecursiveBacktracker;
+        private readonly GeneratorOptions.MazeFillFactor _fillFactor =
+            GeneratorOptions.MazeFillFactor.Full;
+
+        /// <summary>
+        /// Creates a world façade.
+        /// </summary>
+        /// <param name="store">The game's persistence seam. Use a
+        /// <see cref="NullRegionStore"/> to always regenerate and persist
+        /// nothing.</param>
+        /// <param name="worldSeed">The base seed; each region derives its own
+        /// seed from this and its address, so regions are independently
+        /// reproducible.</param>
+        /// <param name="regionMazeSize">The region size in <i>maze</i> cells
+        /// (before Block expansion). The rendered Block size is larger; read it
+        /// from <see cref="RegionView.Size"/>.</param>
+        /// <param name="renderOptions">Block cell sizing. Defaults to
+        /// <see cref="Maze2DRendererOptions.RectCells(int,int)"/> of (2, 1).
+        /// </param>
+        public World(IRegionStore store, int worldSeed, Vector regionMazeSize,
+                     Maze2DRendererOptions renderOptions = null) {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+            _worldSeed = worldSeed;
+            regionMazeSize.ThrowIfNotAValidSize(nameof(regionMazeSize));
+            _regionMazeSize = regionMazeSize;
+            _renderOptions = renderOptions ??
+                Maze2DRendererOptions.RectCells(2, 1);
+        }
+
+        /// <summary>
+        /// Returns the region at <paramref name="address"/>: the stored region
+        /// if the store has one, otherwise a freshly generated region that is
+        /// then saved. Synchronous; no streaming.
+        /// </summary>
+        /// <param name="address">The region's address on the region lattice.
+        /// </param>
+        /// <returns>The region as a read-only <see cref="RegionView"/>.</returns>
+        public RegionView GetOrCreate(RegionAddress address) {
+            if (_store.TryLoad(address, out var serialized) &&
+                !string.IsNullOrEmpty(serialized)) {
+                var loaded = new AreaSerializer().Deserialize(serialized);
+                return new RegionView(address, loaded);
+            }
+            var region = Generate(address);
+            _store.Save(address, new AreaSerializer().Serialize(region));
+            return new RegionView(address, region);
+        }
+
+        private int SeedFor(RegionAddress address) {
+            var seed = _worldSeed;
+            foreach (var component in address.Value.Value) {
+                seed = unchecked(seed * 397 + component);
+            }
+            return seed;
+        }
+
+        private Area Generate(RegionAddress address) {
+            var randomSource = RandomSource.FromSeed(SeedFor(address));
+            var options = new GeneratorOptions() {
+                RandomSource = randomSource,
+                MazeAlgorithm = _algorithm,
+                FillFactor = _fillFactor,
+            };
+            var builder = new GeneratedWorld(randomSource)
+                .AddLayer(AreaType.Maze, _regionMazeSize)
+                .OfMaze(MazeStructureStyle.Border, options)
+                .MarkLongestPath()
+                .MarkDeadends();
+
+            // Capture the POIs on the Border maze BEFORE ToMap discards the
+            // marker attachments; bridge them into Block coordinates after.
+            var mazeArea = builder.Map();
+            var entrance = mazeArea.Grid.Single(v =>
+                mazeArea[v]
+                    .X<DijkstraDistance.IsLongestTrailStartExtension>() != null);
+            var exit = mazeArea.Grid.Single(v =>
+                mazeArea[v]
+                    .X<DijkstraDistance.IsLongestTrailEndExtension>() != null);
+            var deadEnds = mazeArea.X<DeadEnd.DeadEndsExtension>().DeadEnds;
+
+            builder.ToMap(_renderOptions);
+            var blockMap = builder.Map();
+
+            BakePoi(blockMap, mazeArea, entrance, PoiKind.Entrance);
+            BakePoi(blockMap, mazeArea, exit, PoiKind.Exit);
+            foreach (var deadEnd in deadEnds
+                         .Where(de => de != entrance && de != exit)) {
+                BakePoi(blockMap, mazeArea, deadEnd, PoiKind.DeadEnd);
+            }
+            return blockMap;
+        }
+
+        // Translates a POI on the Border maze into the Block cell at the centre
+        // of that maze cell, and tags it so the POI is a first-class,
+        // serializable property of the region.
+        private void BakePoi(Area blockMap, Area mazeArea, Vector mazeCell,
+                             PoiKind kind) {
+            var mapping = new CellsMapping(
+                blockMap, mazeCell - mazeArea.Position, _renderOptions);
+            blockMap[mapping.CenterPosition].Tags.Add(
+                new Cell.CellTag(RegionTags.For(kind)));
+        }
+    }
+}

--- a/src/world/World.cs
+++ b/src/world/World.cs
@@ -33,7 +33,8 @@ namespace PlayersWorlds.Maps.World {
             GeneratorOptions.MazeFillFactor.Full;
 
         /// <summary>
-        /// Creates a world façade.
+        /// Creates a world façade with <b>square</b> 1×1 Block cells — the
+        /// correct default for a game whose tiles are square in world space.
         /// </summary>
         /// <param name="store">The game's persistence seam. Use a
         /// <see cref="NullRegionStore"/> to always regenerate and persist
@@ -44,17 +45,33 @@ namespace PlayersWorlds.Maps.World {
         /// <param name="regionMazeSize">The region size in <i>maze</i> cells
         /// (before Block expansion). The rendered Block size is larger; read it
         /// from <see cref="RegionView.Size"/>.</param>
-        /// <param name="renderOptions">Block cell sizing. Defaults to
-        /// <see cref="Maze2DRendererOptions.RectCells(int,int)"/> of (2, 1).
+        public World(IRegionStore store, int worldSeed, Vector regionMazeSize)
+            : this(store, worldSeed, regionMazeSize,
+                   new Vector(1, 1), new Vector(1, 1)) { }
+
+        /// <summary>
+        /// Creates a world façade with explicit Block cell sizing — the client
+        /// owns the cell shape. Non-square sizes stretch the region; a game
+        /// wanting square tiles passes equal, square sizes (the default ctor).
+        /// </summary>
+        /// <param name="store">The game's persistence seam.</param>
+        /// <param name="worldSeed">The base seed for per-region seeding.</param>
+        /// <param name="regionMazeSize">The region size in <i>maze</i> cells.
         /// </param>
+        /// <param name="cellSize">The size, in Block cells, of each maze cell's
+        /// walkable interior (corridor width). Use <c>(1, 1)</c> for square.
+        /// </param>
+        /// <param name="wallSize">The size, in Block cells, of the walls between
+        /// maze cells (wall thickness). Use <c>(1, 1)</c> for square.</param>
         public World(IRegionStore store, int worldSeed, Vector regionMazeSize,
-                     Maze2DRendererOptions renderOptions = null) {
+                     Vector cellSize, Vector wallSize) {
             _store = store ?? throw new ArgumentNullException(nameof(store));
             _worldSeed = worldSeed;
             regionMazeSize.ThrowIfNotAValidSize(nameof(regionMazeSize));
             _regionMazeSize = regionMazeSize;
-            _renderOptions = renderOptions ??
-                Maze2DRendererOptions.RectCells(2, 1);
+            cellSize.ThrowIfNotAValidSize(nameof(cellSize));
+            wallSize.ThrowIfNotAValidSize(nameof(wallSize));
+            _renderOptions = Maze2DRendererOptions.RectCells(cellSize, wallSize);
         }
 
         /// <summary>

--- a/tasks/release.sh
+++ b/tasks/release.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Cut a release: bump the version, create an annotated git tag, and push it.
+# CI (.github/workflows/publish.yml) packs and publishes to NuGet on the tag.
+#
+# Usage: tasks/release.sh <patch|minor|major>   (default: minor)
+# The tag is pushed to the remote that hosts the publishing repo (krmrn42/
+# maze-gen), since its GitHub Actions do the publish. Override with RELEASE_REMOTE.
+set -euo pipefail
+
+bump="${1:-minor}"
+case "$bump" in
+  patch|minor|major) ;;
+  *) echo "Unknown bump '$bump' (use patch|minor|major)." >&2; exit 1 ;;
+esac
+
+# Pick the remote pointing at the publishing repo; fall back to origin.
+remote="${RELEASE_REMOTE:-$(git remote -v | awk '/krmrn42\/maze-gen/ {print $1; exit}')}"
+remote="${remote:-origin}"
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Working tree is not clean; commit or stash before releasing." >&2
+  exit 1
+fi
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" != "main" ]; then
+  echo "Warning: releasing from '$branch', not 'main'." >&2
+fi
+
+git fetch --tags "$remote" >/dev/null 2>&1 || true
+latest="$(git tag --list 'v*' --sort=-v:refname | head -n1)"
+latest="${latest:-v0.0.0}"
+
+ver="${latest#v}"
+major="${ver%%.*}"; rest="${ver#*.}"
+minor="${rest%%.*}"; patch="${rest#*.}"
+patch="${patch%%[-+]*}"   # drop any prerelease/build suffix
+
+case "$bump" in
+  major) major=$((major + 1)); minor=0; patch=0 ;;
+  minor) minor=$((minor + 1)); patch=0 ;;
+  patch) patch=$((patch + 1)) ;;
+esac
+new="v${major}.${minor}.${patch}"
+
+if git rev-parse -q --verify "refs/tags/$new" >/dev/null; then
+  echo "Tag $new already exists." >&2
+  exit 1
+fi
+
+echo "Releasing $latest -> $new  (remote: $remote, branch: $branch)"
+git tag -a "$new" -m "Release $new"
+git push "$remote" "$new"
+echo "Pushed $new. CI (publish.yml) will pack and publish $new to NuGet."

--- a/tests/examples/Phase0RegionContractExample.cs
+++ b/tests/examples/Phase0RegionContractExample.cs
@@ -1,0 +1,82 @@
+using System.Linq;
+using NUnit.Framework;
+using PlayersWorlds.Maps.Areas;
+using PlayersWorlds.Maps.Maze;
+using PlayersWorlds.Maps.Maze.PostProcessing;
+using PlayersWorlds.Maps.Serializer;
+using static PlayersWorlds.Maps.Maze.Maze2DRenderer;
+
+namespace PlayersWorlds.Maps.Examples {
+    /// <summary>
+    /// Worked example for the Phase-0 region contract (see
+    /// <c>openspec/changes/maze-gen-mazzzze-phase0-contract</c>). It documents
+    /// two maze-gen behaviours the façade / store seam depends on:
+    /// <list type="number">
+    /// <item>the <b>corrected POIs</b> — after the S6 fix, the longest-path
+    /// entrance and exit resolve to two <i>distinct</i> cells;</item>
+    /// <item>the <b>lossless round-trip</b> — <see cref="AreaSerializer"/>
+    /// preserves the maze structure (cells + hard links), so a stored region
+    /// reloads identically and its POIs can be <i>recomputed</i> from the
+    /// reloaded structure (POI markers are extension attachments and are not
+    /// themselves serialized — a deterministic recompute is the contract).
+    /// </item>
+    /// </list>
+    /// </summary>
+    [TestFixture]
+    public class Phase0RegionContractExample : Test {
+        [Test]
+        public void CorrectedPois_AndLosslessRoundTrip() {
+            // 1. Generate a region (a Border maze) and mark its longest path.
+            var world = new GeneratedWorld(RandomSource)
+                .AddLayer(AreaType.Maze, new Vector(12, 12))
+                .OfMaze(MazeStructureStyle.Border, new GeneratorOptions() {
+                    MazeAlgorithm = GeneratorOptions.Algorithms.RecursiveBacktracker,
+                    FillFactor = GeneratorOptions.MazeFillFactor.Full
+                })
+                .MarkLongestPath();
+            var region = world.Map();
+
+            // 2. Corrected POIs: entrance and exit are two DISTINCT cells.
+            //    (Before the S6 fix the end marker was written onto the start
+            //    cell, so entrance == exit.)
+            var entrance = region.Grid.Single(v =>
+                region[v].X<DijkstraDistance.IsLongestTrailStartExtension>() != null);
+            var exit = region.Grid.Single(v =>
+                region[v].X<DijkstraDistance.IsLongestTrailEndExtension>() != null);
+            Assert.That(entrance, Is.Not.EqualTo(exit),
+                "entrance and exit POIs must be distinct cells");
+
+            var originalTrail =
+                region.X<DijkstraDistance.LongestTrailExtension>().LongestTrail;
+            Assert.That(originalTrail.First(), Is.EqualTo(entrance));
+            Assert.That(originalTrail.Last(), Is.EqualTo(exit));
+
+            // 3. Lossless round-trip through the store-seam serializer.
+            var serializer = new AreaSerializer();
+            var reloaded = serializer.Deserialize(serializer.Serialize(region));
+
+            // Structure survives: same size and the exact same hard links.
+            Assert.That(reloaded.Size, Is.EqualTo(region.Size));
+            var originalLinks = region.Grid.Sum(v => region[v].HardLinks.Count);
+            var reloadedLinks = reloaded.Grid.Sum(v => reloaded[v].HardLinks.Count);
+            Assert.That(reloadedLinks, Is.EqualTo(originalLinks));
+
+            // POI markers are NOT serialized -- the reloaded region has none...
+            Assert.That(reloaded.Grid.Any(v =>
+                reloaded[v].X<DijkstraDistance.IsLongestTrailStartExtension>() != null),
+                Is.False);
+
+            // ...they are recomputed from the reloaded structure, and because
+            // generation is deterministic the recomputed trail has the same
+            // length as the original.
+            var recomputed = DijkstraDistance.FindLongestTrail(reloaded);
+            Assert.That(recomputed.LongestTrail.Count,
+                Is.EqualTo(originalTrail.Count));
+            var reEntrance = reloaded.Grid.Single(v =>
+                reloaded[v].X<DijkstraDistance.IsLongestTrailStartExtension>() != null);
+            var reExit = reloaded.Grid.Single(v =>
+                reloaded[v].X<DijkstraDistance.IsLongestTrailEndExtension>() != null);
+            Assert.That(reEntrance, Is.Not.EqualTo(reExit));
+        }
+    }
+}

--- a/tests/maze/post_processing/DijkstraDistanceTest.cs
+++ b/tests/maze/post_processing/DijkstraDistanceTest.cs
@@ -53,6 +53,27 @@ namespace PlayersWorlds.Maps.Maze.PostProcessing {
                 cell => cell.X<DijkstraDistance.IsLongestTrailStartExtension>() != null), Is.EqualTo(1));
             Assert.That(maze.Count(
                 cell => cell.X<DijkstraDistance.IsLongestTrailEndExtension>() != null), Is.EqualTo(1));
+            // S6 regression guard: the start and the end must be two DISTINCT
+            // cells. The original defect tagged the end marker onto the start
+            // cell, so a single cell carried both markers while the per-cell
+            // counts above still read 1/1. Assert no cell holds both.
+            Assert.That(maze.Count(cell =>
+                cell.X<DijkstraDistance.IsLongestTrailStartExtension>() != null &&
+                cell.X<DijkstraDistance.IsLongestTrailEndExtension>() != null),
+                Is.EqualTo(0));
+            // S6 regression guard: every cell on the trail is tagged, not just
+            // the start cell (the defect wrote IsLongestTrailExtension onto
+            // startingPoint solution.Count times, tagging exactly one cell).
+            Assert.That(maze.Count(
+                cell => cell.X<DijkstraDistance.IsLongestTrailExtension>() != null),
+                Is.EqualTo(solution.LongestTrail.Count));
+            // Both endpoints lie on the tagged trail.
+            Assert.That(maze.Count(cell =>
+                cell.X<DijkstraDistance.IsLongestTrailStartExtension>() != null &&
+                cell.X<DijkstraDistance.IsLongestTrailExtension>() != null), Is.EqualTo(1));
+            Assert.That(maze.Count(cell =>
+                cell.X<DijkstraDistance.IsLongestTrailEndExtension>() != null &&
+                cell.X<DijkstraDistance.IsLongestTrailExtension>() != null), Is.EqualTo(1));
             // perhaps the caller of FindLongestTrail will add it as maze extension?..
             Assert.That(maze.Count(
                 cell => cell.X<DijkstraDistance.LongestTrailExtension>() != null), Is.EqualTo(0));

--- a/tests/serializer/AreaSerializerTest.cs
+++ b/tests/serializer/AreaSerializerTest.cs
@@ -176,5 +176,37 @@ namespace PlayersWorlds.Maps.Serializer {
             Assert.That(
                 deserializedArea[new Vector(0, 0)].HasLinks(new Vector(0, 1)));
         }
+
+        // D5 trap (docs/COMPONENT-REVIEW.md): the store seam behind
+        // IRegionStore MUST round-trip through AreaSerializer, which is
+        // lossless, and MUST NOT use GeneratedWorld.Serialize() /
+        // Area.ToString(), which return a short debug label that drops all
+        // cells and links and does not deserialize back into an Area.
+        [Test]
+        public void AreaSerializerIsLossless_ToStringIsADebugLabelTrap() {
+            var area = Area.CreateMaze(new Vector(5, 5));
+            area[new Vector(0, 0)].HardLinks.Add(new Vector(0, 1));
+            area[new Vector(0, 1)].HardLinks.Add(new Vector(0, 0));
+
+            // Lossless: links survive a full AreaSerializer round trip -- this
+            // is the path the store seam uses.
+            var roundTripped =
+                _serializer.Deserialize(_serializer.Serialize(area));
+            Assert.That(
+                roundTripped[new Vector(0, 0)].HasLinks(new Vector(0, 1)),
+                Is.True);
+
+            // The trap: Area.ToString() (exactly what GeneratedWorld.Serialize()
+            // returns) is a debug label carrying no cell/link data...
+            var debugLabel = area.ToString();
+            Assert.That(debugLabel, Does.Not.Contain("Cell"));
+            // ...and it is not even a valid serialized Area, so feeding it to
+            // the store's deserializer fails loudly rather than silently
+            // reconstructing an empty, link-less region.
+            Assert.That(() => _serializer.Deserialize(debugLabel),
+                Throws.Exception,
+                "GeneratedWorld.Serialize()/Area.ToString() must not be fed " +
+                "to the store seam; it is a lossy debug label, not a format.");
+        }
     }
 }

--- a/tests/world/GateTest.cs
+++ b/tests/world/GateTest.cs
@@ -1,0 +1,15 @@
+using NUnit.Framework;
+
+namespace PlayersWorlds.Maps.World {
+    [TestFixture]
+    public class GateTest {
+        [Test]
+        public void ExposesBorderFaceAndOpenCells() {
+            var open = new[] { new Vector(3, 0), new Vector(3, 1) };
+            var gate = new Gate(1, true, open);
+            Assert.That(gate.Dimension, Is.EqualTo(1));
+            Assert.That(gate.AtFarSide, Is.True);
+            Assert.That(gate.OpenCells, Is.EqualTo(open));
+        }
+    }
+}

--- a/tests/world/IRegionStoreTest.cs
+++ b/tests/world/IRegionStoreTest.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+
+namespace PlayersWorlds.Maps.World {
+    [TestFixture]
+    public class IRegionStoreTest {
+        private static readonly RegionAddress Address =
+            new RegionAddress(new Vector(1, 1));
+
+        [Test]
+        public void NullRegionStore_AlwaysMisses() {
+            var store = new NullRegionStore();
+            Assert.That(store.TryLoad(Address, out var blob), Is.False);
+            Assert.That(blob, Is.Null);
+        }
+
+        [Test]
+        public void NullRegionStore_SaveIsANoOp() {
+            var store = new NullRegionStore();
+            Assert.That(() => store.Save(Address, "anything"), Throws.Nothing);
+            // Still a miss after "saving".
+            Assert.That(store.TryLoad(Address, out _), Is.False);
+        }
+    }
+}

--- a/tests/world/InMemoryRegionStore.cs
+++ b/tests/world/InMemoryRegionStore.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace PlayersWorlds.Maps.World {
+    /// <summary>
+    /// A simple recording <see cref="IRegionStore"/> for tests: keeps regions
+    /// in a dictionary and counts saves so a test can assert generate-once.
+    /// </summary>
+    internal class InMemoryRegionStore : IRegionStore {
+        private readonly Dictionary<RegionAddress, string> _blobs =
+            new Dictionary<RegionAddress, string>();
+
+        public int SaveCount { get; private set; }
+        public int Count => _blobs.Count;
+
+        public bool TryLoad(RegionAddress address, out string serializedRegion) =>
+            _blobs.TryGetValue(address, out serializedRegion);
+
+        public void Save(RegionAddress address, string serializedRegion) {
+            SaveCount++;
+            _blobs[address] = serializedRegion;
+        }
+    }
+}

--- a/tests/world/PoiTest.cs
+++ b/tests/world/PoiTest.cs
@@ -1,0 +1,13 @@
+using NUnit.Framework;
+
+namespace PlayersWorlds.Maps.World {
+    [TestFixture]
+    public class PoiTest {
+        [Test]
+        public void ExposesKindAndLocal() {
+            var poi = new Poi(PoiKind.Exit, new Vector(3, 4));
+            Assert.That(poi.Kind, Is.EqualTo(PoiKind.Exit));
+            Assert.That(poi.Local, Is.EqualTo(new Vector(3, 4)));
+        }
+    }
+}

--- a/tests/world/RegionAddressTest.cs
+++ b/tests/world/RegionAddressTest.cs
@@ -68,6 +68,9 @@ namespace PlayersWorlds.Maps.World {
             Assert.That(a != c, Is.True);
             Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
             Assert.That(a.ToString(), Does.Contain("1x2"));
+            // Equals(object) against a non-address is false, not a throw.
+            Assert.That(a.Equals("not an address"), Is.False);
+            Assert.That(a.Equals(null), Is.False);
         }
 
         [Test]

--- a/tests/world/RegionAddressTest.cs
+++ b/tests/world/RegionAddressTest.cs
@@ -1,0 +1,90 @@
+using System;
+using NUnit.Framework;
+
+namespace PlayersWorlds.Maps.World {
+    [TestFixture]
+    public class RegionAddressTest {
+        [Test]
+        public void ToWorld_And_FromWorld_RoundTrip_2D() {
+            var address = new RegionAddress(new Vector(2, -3));
+            var regionSize = new Vector(42, 21);
+            var local = new Vector(5, 7);
+
+            var world = address.ToWorld(regionSize, local);
+            Assert.That(world, Is.EqualTo(new Vector(2 * 42 + 5, -3 * 21 + 7)));
+
+            var (backAddress, backLocal) =
+                RegionAddress.FromWorld(world, regionSize);
+            Assert.That(backAddress, Is.EqualTo(address));
+            Assert.That(backLocal, Is.EqualTo(local));
+        }
+
+        [Test]
+        public void FromWorld_UsesFlooredDivision_ForNegativeCoordinates() {
+            var regionSize = new Vector(10, 10);
+            // world (-1, -1) belongs to region (-1, -1) with local (9, 9).
+            var (address, local) =
+                RegionAddress.FromWorld(new Vector(-1, -1), regionSize);
+            Assert.That(address, Is.EqualTo(new RegionAddress(new Vector(-1, -1))));
+            Assert.That(local, Is.EqualTo(new Vector(9, 9)));
+            // and it round-trips back.
+            Assert.That(address.ToWorld(regionSize, local),
+                Is.EqualTo(new Vector(-1, -1)));
+        }
+
+        [Test]
+        public void RoundTrip_HoldsAcrossAWholeRegionSpan() {
+            var regionSize = new Vector(4, 3);
+            for (var wx = -6; wx <= 6; wx++) {
+                for (var wy = -6; wy <= 6; wy++) {
+                    var world = new Vector(wx, wy);
+                    var (address, local) =
+                        RegionAddress.FromWorld(world, regionSize);
+                    Assert.That(local.X, Is.InRange(0, regionSize.X - 1));
+                    Assert.That(local.Y, Is.InRange(0, regionSize.Y - 1));
+                    Assert.That(address.ToWorld(regionSize, local),
+                        Is.EqualTo(world));
+                }
+            }
+        }
+
+        [Test]
+        public void IsNDimensional() {
+            var address = new RegionAddress(new Vector(new[] { 1, 2, 3 }));
+            var regionSize = new Vector(new[] { 10, 10, 10 });
+            var local = new Vector(new[] { 4, 5, 6 });
+            Assert.That(address.Dimensions, Is.EqualTo(3));
+            Assert.That(address.ToWorld(regionSize, local),
+                Is.EqualTo(new Vector(new[] { 14, 25, 36 })));
+        }
+
+        [Test]
+        public void Equality_And_HashCode() {
+            var a = new RegionAddress(new Vector(1, 2));
+            var b = new RegionAddress(new Vector(1, 2));
+            var c = new RegionAddress(new Vector(1, 3));
+            Assert.That(a, Is.EqualTo(b));
+            Assert.That(a == b, Is.True);
+            Assert.That(a != c, Is.True);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+            Assert.That(a.ToString(), Does.Contain("1x2"));
+        }
+
+        [Test]
+        public void EmptyCoordinate_Throws() {
+            Assert.That(() => new RegionAddress(Vector.Empty),
+                Throws.ArgumentException);
+        }
+
+        [Test]
+        public void DimensionMismatch_Throws() {
+            var address = new RegionAddress(new Vector(1, 2));
+            Assert.That(() => address.ToWorld(
+                    new Vector(new[] { 1, 2, 3 }), new Vector(0, 0)),
+                Throws.ArgumentException);
+            Assert.That(() => RegionAddress.FromWorld(new Vector(1, 2),
+                    new Vector(new[] { 1, 2, 3 })),
+                Throws.ArgumentException);
+        }
+    }
+}

--- a/tests/world/RegionAlgorithmTest.cs
+++ b/tests/world/RegionAlgorithmTest.cs
@@ -12,6 +12,11 @@ namespace PlayersWorlds.Maps.World {
 
         private abstract class AbstractGen : MazeGenerator { }
 
+        private sealed class NoDefaultCtorGen : MazeGenerator {
+            public NoDefaultCtorGen(int _) { }
+            public override void GenerateMaze(Maze2DBuilder builder) { }
+        }
+
         [Test]
         public void BuiltIns_AreDistinct() {
             Assert.That(RegionAlgorithm.RecursiveBacktracker,
@@ -20,6 +25,22 @@ namespace PlayersWorlds.Maps.World {
                 Is.EqualTo(RegionAlgorithm.RecursiveBacktracker));
             Assert.That(RegionAlgorithm.HuntAndKill.GetHashCode(),
                 Is.EqualTo(RegionAlgorithm.HuntAndKill.GetHashCode()));
+        }
+
+        [Test]
+        public void AllBuiltIns_AreUsable_AndDefaultIsDistinct() {
+            var all = new[] {
+                RegionAlgorithm.RecursiveBacktracker, RegionAlgorithm.AldousBroder,
+                RegionAlgorithm.HuntAndKill, RegionAlgorithm.Wilsons,
+                RegionAlgorithm.Sidewinder, RegionAlgorithm.BinaryTree,
+            };
+            foreach (var algo in all) {
+                Assert.That(algo.ToString(), Is.Not.Empty);
+            }
+            Assert.That(RegionAlgorithm.RecursiveBacktracker.Equals("not an algo"),
+                Is.False);
+            Assert.That(default(RegionAlgorithm).ToString(), Is.EqualTo("<default>"));
+            Assert.That(default(RegionAlgorithm).GetHashCode(), Is.EqualTo(0));
         }
 
         [Test]
@@ -36,6 +57,8 @@ namespace PlayersWorlds.Maps.World {
                 Throws.ArgumentException);
             Assert.That(() => RegionAlgorithm.Custom(null),
                 Throws.InstanceOf<ArgumentNullException>());
+            Assert.That(() => RegionAlgorithm.Custom(typeof(NoDefaultCtorGen)),
+                Throws.ArgumentException);
         }
     }
 }

--- a/tests/world/RegionAlgorithmTest.cs
+++ b/tests/world/RegionAlgorithmTest.cs
@@ -1,0 +1,41 @@
+using System;
+using NUnit.Framework;
+using PlayersWorlds.Maps.Maze;
+
+namespace PlayersWorlds.Maps.World {
+    [TestFixture]
+    public class RegionAlgorithmTest {
+        // A valid custom generator (concrete, parameterless ctor).
+        private sealed class CustomGen : MazeGenerator {
+            public override void GenerateMaze(Maze2DBuilder builder) { }
+        }
+
+        private abstract class AbstractGen : MazeGenerator { }
+
+        [Test]
+        public void BuiltIns_AreDistinct() {
+            Assert.That(RegionAlgorithm.RecursiveBacktracker,
+                Is.Not.EqualTo(RegionAlgorithm.Sidewinder));
+            Assert.That(RegionAlgorithm.RecursiveBacktracker,
+                Is.EqualTo(RegionAlgorithm.RecursiveBacktracker));
+            Assert.That(RegionAlgorithm.HuntAndKill.GetHashCode(),
+                Is.EqualTo(RegionAlgorithm.HuntAndKill.GetHashCode()));
+        }
+
+        [Test]
+        public void Custom_AcceptsAConcreteGenerator() {
+            var algo = RegionAlgorithm.Custom<CustomGen>();
+            Assert.That(algo.ToString(), Is.EqualTo(nameof(CustomGen)));
+        }
+
+        [Test]
+        public void Custom_RejectsNonGenerators_AndAbstractOrNull() {
+            Assert.That(() => RegionAlgorithm.Custom(typeof(string)),
+                Throws.ArgumentException);
+            Assert.That(() => RegionAlgorithm.Custom(typeof(AbstractGen)),
+                Throws.ArgumentException);
+            Assert.That(() => RegionAlgorithm.Custom(null),
+                Throws.InstanceOf<ArgumentNullException>());
+        }
+    }
+}

--- a/tests/world/RegionCellTest.cs
+++ b/tests/world/RegionCellTest.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using PlayersWorlds.Maps.Areas;
+
+namespace PlayersWorlds.Maps.World {
+    [TestFixture]
+    public class RegionCellTest {
+        [Test]
+        public void ExposesPayload() {
+            var cell = new RegionCell(true, AreaType.Hall,
+                new[] { "A", "B" });
+            Assert.That(cell.IsPassable, Is.True);
+            Assert.That(cell.Type, Is.EqualTo(AreaType.Hall));
+            Assert.That(cell.Tags, Is.EqualTo(new[] { "A", "B" }));
+        }
+
+        [Test]
+        public void NullTags_ReadAsEmpty() {
+            var cell = new RegionCell(false, AreaType.None, null);
+            Assert.That(cell.IsPassable, Is.False);
+            Assert.That(cell.Tags, Is.Empty);
+        }
+    }
+}

--- a/tests/world/RegionRecipeTest.cs
+++ b/tests/world/RegionRecipeTest.cs
@@ -49,5 +49,36 @@ namespace PlayersWorlds.Maps.World {
             Assert.That(recipe.CellSize, Is.EqualTo(new Vector(3, 1)));
             Assert.That(recipe.WallSize, Is.EqualTo(new Vector(1, 1)));
         }
+
+        [Test]
+        public void WithRooms_AccumulatesRequests_Immutably() {
+            var basic = RegionRecipe.Maze;
+            var withRooms = basic.WithRooms(3, new Vector(4, 4),
+                new Vector(6, 6), RoomKind.Hall, "armory");
+            Assert.That(basic.Rooms, Is.Empty);              // original untouched
+            Assert.That(withRooms.Rooms.Count, Is.EqualTo(1));
+            Assert.That(withRooms.Rooms[0].Kind, Is.EqualTo(RoomKind.Hall));
+            Assert.That(withRooms.Rooms[0].Count, Is.EqualTo(3));
+            Assert.That(withRooms.Rooms[0].Tags, Does.Contain("armory"));
+
+            var two = withRooms.WithRooms(2, new Vector(3, 3),
+                new Vector(3, 3), RoomKind.Cave);
+            Assert.That(two.Rooms.Count, Is.EqualTo(2));     // mixed kinds
+        }
+
+        [Test]
+        public void RoomPresets_HaveRooms_PlainOnesDoNot() {
+            Assert.That(RegionRecipe.Dungeon.Rooms, Is.Not.Empty);
+            Assert.That(RegionRecipe.Caverns.Rooms, Is.Not.Empty);
+            Assert.That(RegionRecipe.Maze.Rooms, Is.Empty);
+            Assert.That(RegionRecipe.Corridors.Rooms, Is.Empty);
+        }
+
+        [Test]
+        public void WithRooms_RejectsNegativeCount() {
+            Assert.That(() => RegionRecipe.Maze.WithRooms(
+                    -1, new Vector(2, 2), new Vector(3, 3)),
+                Throws.InstanceOf<System.ArgumentOutOfRangeException>());
+        }
     }
 }

--- a/tests/world/RegionRecipeTest.cs
+++ b/tests/world/RegionRecipeTest.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+
+namespace PlayersWorlds.Maps.World {
+    [TestFixture]
+    public class RegionRecipeTest {
+        [Test]
+        public void Presets_HaveSquareCellsByDefault() {
+            Assert.That(RegionRecipe.Maze.CellSize, Is.EqualTo(new Vector(1, 1)));
+            Assert.That(RegionRecipe.Maze.WallSize, Is.EqualTo(new Vector(1, 1)));
+            Assert.That(RegionRecipe.Maze.Fill, Is.EqualTo(1.0));
+        }
+
+        [Test]
+        public void Presets_DifferByAlgorithm() {
+            Assert.That(RegionRecipe.Maze.Algorithm,
+                Is.EqualTo(RegionAlgorithm.RecursiveBacktracker));
+            Assert.That(RegionRecipe.Corridors.Algorithm,
+                Is.EqualTo(RegionAlgorithm.Sidewinder));
+        }
+
+        [Test]
+        public void With_ReturnsANewRecipe_LeavingTheOriginalUntouched() {
+            var basic = RegionRecipe.Maze;
+            var tuned = basic
+                .WithAlgorithm(RegionAlgorithm.HuntAndKill)
+                .WithFill(0.5)
+                .WithCells(2);
+
+            Assert.That(tuned.Algorithm, Is.EqualTo(RegionAlgorithm.HuntAndKill));
+            Assert.That(tuned.Fill, Is.EqualTo(0.5));
+            Assert.That(tuned.CellSize, Is.EqualTo(new Vector(2, 2)));
+            // original unchanged (immutable)
+            Assert.That(basic.Algorithm,
+                Is.EqualTo(RegionAlgorithm.RecursiveBacktracker));
+            Assert.That(basic.Fill, Is.EqualTo(1.0));
+            Assert.That(basic.CellSize, Is.EqualTo(new Vector(1, 1)));
+        }
+
+        [Test]
+        public void WithFill_IsClampedTo01() {
+            Assert.That(RegionRecipe.Maze.WithFill(5.0).Fill, Is.EqualTo(1.0));
+            Assert.That(RegionRecipe.Maze.WithFill(-1.0).Fill, Is.EqualTo(0.0));
+        }
+
+        [Test]
+        public void WithCells_TakesExplicitCorridorAndWallSizes() {
+            var recipe = RegionRecipe.Maze
+                .WithCells(new Vector(3, 1), new Vector(1, 1));
+            Assert.That(recipe.CellSize, Is.EqualTo(new Vector(3, 1)));
+            Assert.That(recipe.WallSize, Is.EqualTo(new Vector(1, 1)));
+        }
+    }
+}

--- a/tests/world/RegionTagsTest.cs
+++ b/tests/world/RegionTagsTest.cs
@@ -1,0 +1,23 @@
+using System;
+using NUnit.Framework;
+
+namespace PlayersWorlds.Maps.World {
+    [TestFixture]
+    public class RegionTagsTest {
+        [Test]
+        public void For_MapsEachKindToItsTag() {
+            Assert.That(RegionTags.For(PoiKind.Entrance),
+                Is.EqualTo(RegionTags.Entrance));
+            Assert.That(RegionTags.For(PoiKind.Exit),
+                Is.EqualTo(RegionTags.Exit));
+            Assert.That(RegionTags.For(PoiKind.DeadEnd),
+                Is.EqualTo(RegionTags.DeadEnd));
+        }
+
+        [Test]
+        public void For_ThrowsForUnknownKind() {
+            Assert.That(() => RegionTags.For((PoiKind)999),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+    }
+}

--- a/tests/world/RegionViewTest.cs
+++ b/tests/world/RegionViewTest.cs
@@ -93,6 +93,9 @@ namespace PlayersWorlds.Maps.World {
             var forbidden = new HashSet<Type> {
                 typeof(Area), typeof(Cell), typeof(ExtensibleObject),
                 typeof(Grid), typeof(Cell.CellTag),
+                // No renderer/rendering-option types in the game contract.
+                typeof(Maze.Maze2DRenderer),
+                typeof(Maze.Maze2DRenderer.Maze2DRendererOptions),
             };
 
             bool IsForbidden(Type t) {

--- a/tests/world/RegionViewTest.cs
+++ b/tests/world/RegionViewTest.cs
@@ -12,7 +12,7 @@ namespace PlayersWorlds.Maps.World {
             new RegionAddress(new Vector(0, 0));
 
         private static RegionView Generate(int seed) =>
-            new World(new NullRegionStore(), seed, new Vector(6, 6))
+            new World(new NullRegionStore(), seed, new Vector(13, 13))
                 .GetOrCreate(Origin);
 
         [Test]
@@ -53,7 +53,7 @@ namespace PlayersWorlds.Maps.World {
 
         [Test]
         public void ToWorld_OffsetsByAddress() {
-            var region = new World(new NullRegionStore(), 5, new Vector(6, 6))
+            var region = new World(new NullRegionStore(), 5, new Vector(13, 13))
                 .GetOrCreate(new RegionAddress(new Vector(2, 3)));
             var local = new Vector(1, 1);
             Assert.That(region.ToWorld(local),

--- a/tests/world/RegionViewTest.cs
+++ b/tests/world/RegionViewTest.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using PlayersWorlds.Maps.Areas;
+
+namespace PlayersWorlds.Maps.World {
+    [TestFixture]
+    public class RegionViewTest {
+        private static readonly RegionAddress Origin =
+            new RegionAddress(new Vector(0, 0));
+
+        private static RegionView Generate(int seed) =>
+            new World(new NullRegionStore(), seed, new Vector(6, 6))
+                .GetOrCreate(Origin);
+
+        [Test]
+        public void CellAt_ReportsPassabilityAndTags() {
+            var region = Generate(12345);
+            var entrance = region.Pois.Single(p => p.Kind == PoiKind.Entrance);
+            var cell = region.CellAt(entrance.Local);
+            Assert.That(cell.IsPassable, Is.True);
+            Assert.That(cell.Type, Is.EqualTo(AreaType.Environment));
+            Assert.That(cell.Tags, Does.Contain(RegionTags.Entrance));
+        }
+
+        [Test]
+        public void Contains_AndCellAt_RespectBounds() {
+            var region = Generate(1);
+            Assert.That(region.Contains(new Vector(0, 0)), Is.True);
+            Assert.That(region.Contains(region.Size), Is.False);
+            Assert.That(() => region.CellAt(region.Size),
+                Throws.InstanceOf<IndexOutOfRangeException>());
+        }
+
+        [Test]
+        public void Pois_HaveDistinctEntranceAndExit_AndOptionalDeadEnds() {
+            var region = Generate(777);
+            Assert.That(region.Pois.Count(p => p.Kind == PoiKind.Entrance),
+                Is.EqualTo(1));
+            Assert.That(region.Pois.Count(p => p.Kind == PoiKind.Exit),
+                Is.EqualTo(1));
+            var entrance = region.Pois.Single(p => p.Kind == PoiKind.Entrance);
+            var exit = region.Pois.Single(p => p.Kind == PoiKind.Exit);
+            Assert.That(entrance.Local, Is.Not.EqualTo(exit.Local));
+            // Dead ends never coincide with the entrance/exit cells.
+            var endpoints = new[] { entrance.Local, exit.Local };
+            foreach (var deadEnd in region.Pois.Where(p => p.Kind == PoiKind.DeadEnd)) {
+                Assert.That(endpoints, Does.Not.Contain(deadEnd.Local));
+            }
+        }
+
+        [Test]
+        public void ToWorld_OffsetsByAddress() {
+            var region = new World(new NullRegionStore(), 5, new Vector(6, 6))
+                .GetOrCreate(new RegionAddress(new Vector(2, 3)));
+            var local = new Vector(1, 1);
+            Assert.That(region.ToWorld(local),
+                Is.EqualTo(new Vector(2 * region.Size.X + 1,
+                                      3 * region.Size.Y + 1)));
+        }
+
+        [Test]
+        public void Gates_SurfacePassableBorderCells() {
+            // A normal closed region has a fully walled border, so build a small
+            // synthetic region with one passable cell on the x==0 border to
+            // exercise gate detection directly.
+            var area = Area.Create(new Vector(0, 0), new Vector(4, 4),
+                AreaType.Environment);
+            area[new Vector(0, 1)].Tags.Add(Cell.CellTag.MazeTrail);
+            var region = new RegionView(Origin, area);
+
+            Assert.That(region.Gates.Count, Is.EqualTo(1));
+            var gate = region.Gates.Single();
+            Assert.That(gate.Dimension, Is.EqualTo(0));
+            Assert.That(gate.AtFarSide, Is.False);
+            Assert.That(gate.OpenCells, Does.Contain(new Vector(0, 1)));
+        }
+
+        [Test]
+        public void GeneratedRegion_IsAClosedBox_WithNoGates() {
+            // Documents the Phase-0 reality: regions are closed; gate-aware
+            // generation (openings that line up with neighbours) is Phase 2.
+            var region = Generate(31);
+            Assert.That(region.Gates, Is.Empty);
+        }
+
+        // Contract test (task 2.7): nothing on the façade's public surface
+        // leaks Area / Cell / ExtensibleObject / Grid.
+        [Test]
+        public void PublicSurface_LeaksNoInternalTypes() {
+            var forbidden = new HashSet<Type> {
+                typeof(Area), typeof(Cell), typeof(ExtensibleObject),
+                typeof(Grid), typeof(Cell.CellTag),
+            };
+
+            bool IsForbidden(Type t) {
+                if (t == null) return false;
+                if (t.IsArray) return IsForbidden(t.GetElementType());
+                if (t.IsGenericType) {
+                    return t.GetGenericArguments().Any(IsForbidden);
+                }
+                return forbidden.Contains(t);
+            }
+
+            var facadeTypes = typeof(RegionView).Assembly.GetTypes()
+                .Where(t => t.IsPublic &&
+                            t.Namespace == "PlayersWorlds.Maps.World")
+                .ToList();
+            Assert.That(facadeTypes, Is.Not.Empty);
+
+            var offenders = new List<string>();
+            foreach (var type in facadeTypes) {
+                foreach (var p in type.GetProperties(BindingFlags.Public |
+                        BindingFlags.Instance | BindingFlags.Static)) {
+                    if (IsForbidden(p.PropertyType)) {
+                        offenders.Add($"{type.Name}.{p.Name} : {p.PropertyType.Name}");
+                    }
+                }
+                foreach (var m in type.GetMethods(BindingFlags.Public |
+                        BindingFlags.Instance | BindingFlags.Static)
+                        .Where(m => !m.IsSpecialName)) {
+                    if (IsForbidden(m.ReturnType)) {
+                        offenders.Add($"{type.Name}.{m.Name}() : {m.ReturnType.Name}");
+                    }
+                    foreach (var par in m.GetParameters()) {
+                        if (IsForbidden(par.ParameterType)) {
+                            offenders.Add($"{type.Name}.{m.Name}({par.ParameterType.Name})");
+                        }
+                    }
+                }
+                foreach (var f in type.GetFields(BindingFlags.Public |
+                        BindingFlags.Instance | BindingFlags.Static)) {
+                    if (IsForbidden(f.FieldType)) {
+                        offenders.Add($"{type.Name}.{f.Name} : {f.FieldType.Name}");
+                    }
+                }
+                foreach (var ctor in type.GetConstructors(BindingFlags.Public |
+                        BindingFlags.Instance)) {
+                    foreach (var par in ctor.GetParameters()) {
+                        if (IsForbidden(par.ParameterType)) {
+                            offenders.Add($"{type.Name}.ctor({par.ParameterType.Name})");
+                        }
+                    }
+                }
+            }
+
+            Assert.That(offenders, Is.Empty,
+                "façade public surface leaks internal types: " +
+                string.Join(", ", offenders));
+        }
+    }
+}

--- a/tests/world/RoomKindTest.cs
+++ b/tests/world/RoomKindTest.cs
@@ -1,0 +1,14 @@
+using System;
+using NUnit.Framework;
+
+namespace PlayersWorlds.Maps.World {
+    [TestFixture]
+    public class RoomKindTest {
+        [Test]
+        public void CoversTheRoomCapableAreaTypes() {
+            Assert.That(Enum.GetValues(typeof(RoomKind)),
+                Is.EquivalentTo(new[] {
+                    RoomKind.Hall, RoomKind.Cave, RoomKind.Blocked }));
+        }
+    }
+}

--- a/tests/world/RoomRequestTest.cs
+++ b/tests/world/RoomRequestTest.cs
@@ -1,0 +1,17 @@
+using NUnit.Framework;
+
+namespace PlayersWorlds.Maps.World {
+    [TestFixture]
+    public class RoomRequestTest {
+        [Test]
+        public void ExposesItsFields() {
+            var request = new RoomRequest(3, new Vector(2, 2), new Vector(4, 4),
+                RoomKind.Cave, new[] { "shrine" });
+            Assert.That(request.Count, Is.EqualTo(3));
+            Assert.That(request.MinSize, Is.EqualTo(new Vector(2, 2)));
+            Assert.That(request.MaxSize, Is.EqualTo(new Vector(4, 4)));
+            Assert.That(request.Kind, Is.EqualTo(RoomKind.Cave));
+            Assert.That(request.Tags, Is.EqualTo(new[] { "shrine" }));
+        }
+    }
+}

--- a/tests/world/WorldTest.cs
+++ b/tests/world/WorldTest.cs
@@ -124,6 +124,70 @@ namespace PlayersWorlds.Maps.World {
                 Is.EqualTo(Signature(explicitCorridors)));
         }
 
+        // Counts 2x2 fully-passable blocks. A 1-wide maze has none (every open
+        // cell is bordered by walls/corners); a room creates them.
+        private static int OpenSquares(RegionView r) {
+            var count = 0;
+            for (var y = 0; y + 1 < r.Size.Y; y++) {
+                for (var x = 0; x + 1 < r.Size.X; x++) {
+                    if (r.CellAt(new Vector(x, y)).IsPassable &&
+                        r.CellAt(new Vector(x + 1, y)).IsPassable &&
+                        r.CellAt(new Vector(x, y + 1)).IsPassable &&
+                        r.CellAt(new Vector(x + 1, y + 1)).IsPassable) {
+                        count++;
+                    }
+                }
+            }
+            return count;
+        }
+
+        [Test]
+        public void Rooms_OpenUpSpace_ThatAPlainMazeLacks() {
+            // Big enough footprint to hold the Dungeon preset's rooms.
+            var size = new Vector(41, 41);
+            var maze = new World(new NullRegionStore(), 7, size)
+                .GetOrCreate(Origin, RegionRecipe.Maze);
+            var dungeon = new World(new NullRegionStore(), 7, size)
+                .GetOrCreate(Origin, RegionRecipe.Dungeon);
+            Assert.That(OpenSquares(maze), Is.EqualTo(0),
+                "a 1-wide maze has no 2x2 open blocks");
+            Assert.That(OpenSquares(dungeon), Is.GreaterThan(0),
+                "halls create open blocks");
+        }
+
+        [Test]
+        public void AllRoomKinds_GenerateAValidRegion() {
+            var size = new Vector(41, 41);
+            foreach (var kind in new[] {
+                         RoomKind.Hall, RoomKind.Cave, RoomKind.Blocked }) {
+                var region = new World(new NullRegionStore(), 3, size)
+                    .GetOrCreate(Origin, RegionRecipe.Maze.WithRooms(
+                        4, new Vector(6, 6), new Vector(8, 8), kind));
+                var entrance = region.Pois.Single(p => p.Kind == PoiKind.Entrance);
+                var exit = region.Pois.Single(p => p.Kind == PoiKind.Exit);
+                Assert.That(entrance.Local, Is.Not.EqualTo(exit.Local),
+                    $"{kind} region must have distinct entrance/exit");
+            }
+        }
+
+        [Test]
+        public void CavernsPreset_OpensSpace() {
+            var size = new Vector(41, 41);
+            var caverns = new World(new NullRegionStore(), 9, size)
+                .GetOrCreate(Origin, RegionRecipe.Caverns);
+            Assert.That(OpenSquares(caverns), Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void FillDensity_GeneratesAcrossTheRange() {
+            var size = new Vector(21, 21);
+            foreach (var fill in new[] { 0.25, 0.5, 0.75, 0.9 }) {
+                var region = new World(new NullRegionStore(), 7, size)
+                    .GetOrCreate(Origin, RegionRecipe.Maze.WithFill(fill));
+                Assert.That(region.Size, Is.EqualTo(size));
+            }
+        }
+
         [Test]
         public void GetOrCreate_GeneratesOnMiss_ThenLoadsOnHit() {
             var store = new InMemoryRegionStore();

--- a/tests/world/WorldTest.cs
+++ b/tests/world/WorldTest.cs
@@ -5,15 +5,16 @@ using NUnit.Framework;
 namespace PlayersWorlds.Maps.World {
     [TestFixture]
     public class WorldTest {
-        private static readonly Vector RegionMazeSize = new Vector(6, 6);
+        // A region footprint (Block cells) — this is exactly what
+        // RegionView.Size reports. 13 = 2*6+1 fits a 6-cell maze exactly.
+        private static readonly Vector RegionSize = new Vector(13, 13);
         private static readonly RegionAddress Origin =
             new RegionAddress(new Vector(0, 0));
 
         private static World NewWorld(IRegionStore store, int seed) =>
-            new World(store, seed, RegionMazeSize);
+            new World(store, seed, RegionSize);
 
-        // A stable fingerprint of a region's rendered structure + POIs, so two
-        // regions can be compared for equality without exposing internals.
+        // A stable fingerprint of a region's rendered structure + POIs.
         private static string Signature(RegionView region) {
             var sb = new StringBuilder();
             sb.Append(region.Size).Append('|');
@@ -37,46 +38,35 @@ namespace PlayersWorlds.Maps.World {
                 .GetOrCreate(Origin);
 
             Assert.That(region.Address, Is.EqualTo(Origin));
-            Assert.That(region.Size.Area, Is.GreaterThan(RegionMazeSize.Area));
 
-            // Exactly one entrance and one exit, and they are distinct cells.
             var entrance = region.Pois.Single(p => p.Kind == PoiKind.Entrance);
             var exit = region.Pois.Single(p => p.Kind == PoiKind.Exit);
             Assert.That(entrance.Local, Is.Not.EqualTo(exit.Local));
 
-            // Every POI sits on a passable cell.
             foreach (var poi in region.Pois) {
-                Assert.That(region.CellAt(poi.Local).IsPassable, Is.True,
-                    $"POI {poi.Kind} at {poi.Local} must be passable");
+                Assert.That(region.CellAt(poi.Local).IsPassable, Is.True);
             }
-
-            // There is at least some floor.
-            var floors = 0;
-            for (var y = 0; y < region.Size.Y; y++)
-                for (var x = 0; x < region.Size.X; x++)
-                    if (region.CellAt(new Vector(x, y)).IsPassable) floors++;
-            Assert.That(floors, Is.GreaterThan(0));
         }
 
         [Test]
-        public void DefaultCells_AreSquare_NotTheAsciiDebugRatio() {
-            // A square maze must render to a square Block region (each maze cell
-            // is a 1×1 floor with 1-thick walls -> 2N+1 per side). The 2×1
-            // ASCII-console ratio must NOT leak into the game default.
-            var region = NewWorld(new NullRegionStore(), 7).GetOrCreate(Origin);
-            Assert.That(region.Size.X, Is.EqualTo(region.Size.Y),
-                "default region cells must be square");
-            Assert.That(region.Size.X,
-                Is.EqualTo(2 * RegionMazeSize.X + 1));
+        public void RegionSize_IsTheFootprint_ReportedExactlyByRegionView() {
+            var region = NewWorld(new NullRegionStore(), 1).GetOrCreate(Origin);
+            Assert.That(region.Size, Is.EqualTo(RegionSize));
         }
 
         [Test]
-        public void ExplicitCellSizes_LetTheClientShapeCells() {
-            // The client owns cell shape via the explicit ctor.
-            var wide = new World(new NullRegionStore(), 7, RegionMazeSize,
-                cellSize: new Vector(2, 1), wallSize: new Vector(2, 1))
+        public void NonSquareFootprint_IsHonoredInBothDimensions() {
+            var size = new Vector(21, 13);
+            var region = new World(new NullRegionStore(), 1, size)
                 .GetOrCreate(Origin);
-            Assert.That(wide.Size.X, Is.Not.EqualTo(wide.Size.Y));
+            Assert.That(region.Size, Is.EqualTo(size));
+        }
+
+        [Test]
+        public void TooSmallFootprint_Throws() {
+            var world = new World(new NullRegionStore(), 1, new Vector(2, 2));
+            Assert.That(() => world.GetOrCreate(Origin),
+                Throws.ArgumentException);
         }
 
         [Test]
@@ -102,27 +92,66 @@ namespace PlayersWorlds.Maps.World {
         }
 
         [Test]
+        public void PerRegionRecipe_ChangesTheRegion() {
+            var world = NewWorld(new NullRegionStore(), 7);
+            var maze = world.GetOrCreate(Origin, RegionRecipe.Maze);
+            var corridors = world.GetOrCreate(Origin, RegionRecipe.Corridors);
+            // Same footprint, different content.
+            Assert.That(corridors.Size, Is.EqualTo(maze.Size));
+            Assert.That(Signature(corridors), Is.Not.EqualTo(Signature(maze)));
+        }
+
+        [Test]
+        public void ExplicitCellSizes_ChangeStructure_NotFootprint() {
+            var square = NewWorld(new NullRegionStore(), 7).GetOrCreate(Origin);
+            var wide = NewWorld(new NullRegionStore(), 7).GetOrCreate(Origin,
+                RegionRecipe.Maze.WithCells(
+                    new Vector(2, 1), new Vector(1, 1)));
+            Assert.That(wide.Size, Is.EqualTo(square.Size));         // footprint fixed
+            Assert.That(Signature(wide), Is.Not.EqualTo(Signature(square)));
+        }
+
+        [Test]
+        public void DefaultRecipe_IsInheritedUnlessOverridden() {
+            // A world defaulting to Corridors yields the same as passing
+            // Corridors explicitly to a Maze-defaulted world.
+            var defaulted = new World(new NullRegionStore(), 7, RegionSize,
+                    RegionRecipe.Corridors)
+                .GetOrCreate(Origin);
+            var explicitCorridors = NewWorld(new NullRegionStore(), 7)
+                .GetOrCreate(Origin, RegionRecipe.Corridors);
+            Assert.That(Signature(defaulted),
+                Is.EqualTo(Signature(explicitCorridors)));
+        }
+
+        [Test]
         public void GetOrCreate_GeneratesOnMiss_ThenLoadsOnHit() {
             var store = new InMemoryRegionStore();
             var world = NewWorld(store, 555);
 
             var first = world.GetOrCreate(Origin);
             Assert.That(store.SaveCount, Is.EqualTo(1));
-            Assert.That(store.Count, Is.EqualTo(1));
 
             var second = world.GetOrCreate(Origin);
-            // No second save: the stored region was loaded, not regenerated.
             Assert.That(store.SaveCount, Is.EqualTo(1));
             Assert.That(Signature(second), Is.EqualTo(Signature(first)));
         }
 
         [Test]
+        public void Recipe_IsIgnored_WhenTheRegionIsAlreadyStored() {
+            var store = new InMemoryRegionStore();
+            // First generation fixes the region as a Maze.
+            var created = NewWorld(store, 7).GetOrCreate(Origin, RegionRecipe.Maze);
+            // A later call with a different recipe returns the stored region.
+            var reloaded = NewWorld(store, 7)
+                .GetOrCreate(Origin, RegionRecipe.Corridors);
+            Assert.That(Signature(reloaded), Is.EqualTo(Signature(created)));
+        }
+
+        [Test]
         public void StoredRegion_IsLoaded_NotRegenerated() {
             var store = new InMemoryRegionStore();
-            // Seed 1 generates and saves the region.
             var generated = NewWorld(store, 1).GetOrCreate(Origin);
-            // A different seed sharing the store must return the STORED region,
-            // proving it loaded rather than regenerating with the new seed.
             var loaded = NewWorld(store, 999999).GetOrCreate(Origin);
             Assert.That(Signature(loaded), Is.EqualTo(Signature(generated)));
         }
@@ -132,7 +161,6 @@ namespace PlayersWorlds.Maps.World {
             var store = new InMemoryRegionStore();
             var generated = NewWorld(store, 42).GetOrCreate(Origin);
             var reloaded = NewWorld(store, 42).GetOrCreate(Origin);
-            // Full structural + POI equality across the serialize/deserialize.
             Assert.That(Signature(reloaded), Is.EqualTo(Signature(generated)));
             Assert.That(reloaded.Pois.Count, Is.EqualTo(generated.Pois.Count));
         }
@@ -142,7 +170,6 @@ namespace PlayersWorlds.Maps.World {
             var store = new NullRegionStore();
             Assert.That(store.TryLoad(Origin, out var blob), Is.False);
             Assert.That(blob, Is.Null);
-            // A world on a null store still works (regenerates each time).
             var region = NewWorld(store, 3).GetOrCreate(Origin);
             Assert.That(region.Pois.Any(p => p.Kind == PoiKind.Entrance), Is.True);
         }

--- a/tests/world/WorldTest.cs
+++ b/tests/world/WorldTest.cs
@@ -59,6 +59,27 @@ namespace PlayersWorlds.Maps.World {
         }
 
         [Test]
+        public void DefaultCells_AreSquare_NotTheAsciiDebugRatio() {
+            // A square maze must render to a square Block region (each maze cell
+            // is a 1×1 floor with 1-thick walls -> 2N+1 per side). The 2×1
+            // ASCII-console ratio must NOT leak into the game default.
+            var region = NewWorld(new NullRegionStore(), 7).GetOrCreate(Origin);
+            Assert.That(region.Size.X, Is.EqualTo(region.Size.Y),
+                "default region cells must be square");
+            Assert.That(region.Size.X,
+                Is.EqualTo(2 * RegionMazeSize.X + 1));
+        }
+
+        [Test]
+        public void ExplicitCellSizes_LetTheClientShapeCells() {
+            // The client owns cell shape via the explicit ctor.
+            var wide = new World(new NullRegionStore(), 7, RegionMazeSize,
+                cellSize: new Vector(2, 1), wallSize: new Vector(2, 1))
+                .GetOrCreate(Origin);
+            Assert.That(wide.Size.X, Is.Not.EqualTo(wide.Size.Y));
+        }
+
+        [Test]
         public void Generation_IsDeterministic_ForAFixedSeed() {
             var a = NewWorld(new NullRegionStore(), 999).GetOrCreate(Origin);
             var b = NewWorld(new NullRegionStore(), 999).GetOrCreate(Origin);

--- a/tests/world/WorldTest.cs
+++ b/tests/world/WorldTest.cs
@@ -1,0 +1,129 @@
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace PlayersWorlds.Maps.World {
+    [TestFixture]
+    public class WorldTest {
+        private static readonly Vector RegionMazeSize = new Vector(6, 6);
+        private static readonly RegionAddress Origin =
+            new RegionAddress(new Vector(0, 0));
+
+        private static World NewWorld(IRegionStore store, int seed) =>
+            new World(store, seed, RegionMazeSize);
+
+        // A stable fingerprint of a region's rendered structure + POIs, so two
+        // regions can be compared for equality without exposing internals.
+        private static string Signature(RegionView region) {
+            var sb = new StringBuilder();
+            sb.Append(region.Size).Append('|');
+            for (var y = 0; y < region.Size.Y; y++) {
+                for (var x = 0; x < region.Size.X; x++) {
+                    sb.Append(region.CellAt(new Vector(x, y)).IsPassable ? '.' : '#');
+                }
+            }
+            sb.Append('|');
+            foreach (var poi in region.Pois
+                         .OrderBy(p => p.Kind).ThenBy(p => p.Local.X)
+                         .ThenBy(p => p.Local.Y)) {
+                sb.Append(poi.Kind).Append(poi.Local).Append(',');
+            }
+            return sb.ToString();
+        }
+
+        [Test]
+        public void GetOrCreate_GeneratesASolvableRegionWithPois() {
+            var region = NewWorld(new NullRegionStore(), 12345)
+                .GetOrCreate(Origin);
+
+            Assert.That(region.Address, Is.EqualTo(Origin));
+            Assert.That(region.Size.Area, Is.GreaterThan(RegionMazeSize.Area));
+
+            // Exactly one entrance and one exit, and they are distinct cells.
+            var entrance = region.Pois.Single(p => p.Kind == PoiKind.Entrance);
+            var exit = region.Pois.Single(p => p.Kind == PoiKind.Exit);
+            Assert.That(entrance.Local, Is.Not.EqualTo(exit.Local));
+
+            // Every POI sits on a passable cell.
+            foreach (var poi in region.Pois) {
+                Assert.That(region.CellAt(poi.Local).IsPassable, Is.True,
+                    $"POI {poi.Kind} at {poi.Local} must be passable");
+            }
+
+            // There is at least some floor.
+            var floors = 0;
+            for (var y = 0; y < region.Size.Y; y++)
+                for (var x = 0; x < region.Size.X; x++)
+                    if (region.CellAt(new Vector(x, y)).IsPassable) floors++;
+            Assert.That(floors, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void Generation_IsDeterministic_ForAFixedSeed() {
+            var a = NewWorld(new NullRegionStore(), 999).GetOrCreate(Origin);
+            var b = NewWorld(new NullRegionStore(), 999).GetOrCreate(Origin);
+            Assert.That(Signature(a), Is.EqualTo(Signature(b)));
+        }
+
+        [Test]
+        public void DifferentSeeds_ProduceDifferentRegions() {
+            var a = NewWorld(new NullRegionStore(), 1).GetOrCreate(Origin);
+            var b = NewWorld(new NullRegionStore(), 2).GetOrCreate(Origin);
+            Assert.That(Signature(a), Is.Not.EqualTo(Signature(b)));
+        }
+
+        [Test]
+        public void DifferentAddresses_ProduceDifferentRegions() {
+            var world = NewWorld(new NullRegionStore(), 7);
+            var a = world.GetOrCreate(new RegionAddress(new Vector(0, 0)));
+            var b = world.GetOrCreate(new RegionAddress(new Vector(1, 0)));
+            Assert.That(Signature(a), Is.Not.EqualTo(Signature(b)));
+        }
+
+        [Test]
+        public void GetOrCreate_GeneratesOnMiss_ThenLoadsOnHit() {
+            var store = new InMemoryRegionStore();
+            var world = NewWorld(store, 555);
+
+            var first = world.GetOrCreate(Origin);
+            Assert.That(store.SaveCount, Is.EqualTo(1));
+            Assert.That(store.Count, Is.EqualTo(1));
+
+            var second = world.GetOrCreate(Origin);
+            // No second save: the stored region was loaded, not regenerated.
+            Assert.That(store.SaveCount, Is.EqualTo(1));
+            Assert.That(Signature(second), Is.EqualTo(Signature(first)));
+        }
+
+        [Test]
+        public void StoredRegion_IsLoaded_NotRegenerated() {
+            var store = new InMemoryRegionStore();
+            // Seed 1 generates and saves the region.
+            var generated = NewWorld(store, 1).GetOrCreate(Origin);
+            // A different seed sharing the store must return the STORED region,
+            // proving it loaded rather than regenerating with the new seed.
+            var loaded = NewWorld(store, 999999).GetOrCreate(Origin);
+            Assert.That(Signature(loaded), Is.EqualTo(Signature(generated)));
+        }
+
+        [Test]
+        public void StoreRoundTrip_PreservesCellsAndPois() {
+            var store = new InMemoryRegionStore();
+            var generated = NewWorld(store, 42).GetOrCreate(Origin);
+            var reloaded = NewWorld(store, 42).GetOrCreate(Origin);
+            // Full structural + POI equality across the serialize/deserialize.
+            Assert.That(Signature(reloaded), Is.EqualTo(Signature(generated)));
+            Assert.That(reloaded.Pois.Count, Is.EqualTo(generated.Pois.Count));
+        }
+
+        [Test]
+        public void NullRegionStore_PersistsNothing_AlwaysRegenerates() {
+            var store = new NullRegionStore();
+            Assert.That(store.TryLoad(Origin, out var blob), Is.False);
+            Assert.That(blob, Is.Null);
+            // A world on a null store still works (regenerates each time).
+            var region = NewWorld(store, 3).GetOrCreate(Origin);
+            Assert.That(region.Pois.Any(p => p.Kind == PoiKind.Entrance), Is.True);
+        }
+    }
+}

--- a/tests/world/WorldTest.cs
+++ b/tests/world/WorldTest.cs
@@ -156,6 +156,21 @@ namespace PlayersWorlds.Maps.World {
         }
 
         [Test]
+        public void SmallRooms_AreStillVisible_NotCollapsedToCorridors() {
+            // A 3-world-cell room must render as a real (2x2-open-bearing) room,
+            // not vanish into a single corridor cell.
+            var size = new Vector(21, 21);
+            var maze = new World(new NullRegionStore(), 4, size)
+                .GetOrCreate(Origin, RegionRecipe.Maze);
+            var withSmallRooms = new World(new NullRegionStore(), 4, size)
+                .GetOrCreate(Origin, RegionRecipe.Maze.WithRooms(
+                    3, new Vector(3, 3), new Vector(3, 3), RoomKind.Hall));
+            Assert.That(OpenSquares(maze), Is.EqualTo(0));
+            Assert.That(OpenSquares(withSmallRooms), Is.GreaterThan(0),
+                "3x3 rooms must be visible open space");
+        }
+
+        [Test]
         public void AllRoomKinds_GenerateAValidRegion() {
             var size = new Vector(41, 41);
             foreach (var kind in new[] {


### PR DESCRIPTION
## Phase 0 — the maze-gen ↔ mazzzze region contract

Implements OpenSpec change `maze-gen-mazzzze-phase0-contract`: the single, frozen library contract a Godot game codes against, derived top-down from `docs/PRD.md` so it survives the evolution to the endless MMO world.

### What's here

- **New façade** `PlayersWorlds.Maps.World` (`src/world/`) — the frozen public surface, leaking no `Area`/`Cell` internals:
  - `World.GetOrCreate(RegionAddress) → RegionView` — synchronous generate-once-or-load; per-address deterministic seed (new `RandomSource.FromSeed`).
  - `RegionView` — read-only Block cells (`CellAt`/`IsPassable`), `Size`, `Pois` (entrance/exit/dead-ends), `Gates` (Phase-2 seam anchors), `ToWorld`.
  - `RegionCell` / `Poi` / `Gate` / `RegionAddress` value types; `IRegionStore` + `NullRegionStore` blob-persistence seam (engine owns the lossless `AreaSerializer` round-trip).
- **Bug fixes surfaced by the contract:** the **S6** longest-path mis-tag in `DijkstraDistance.FindLongestTrail` (entrance/exit collapsed to one cell) and documentation of the **D5** serialization trap (`AreaSerializer` is lossless; `Serialize()`/`ToString()` are debug labels).
- **Living integration guide** `docs/INTEGRATION.md` covering every `SCENARIOS.md` scenario, kept current by an `openspec/config.yaml` rule auto-injected into every future change. Advances **S1 🔴→✅** and **S3 🟡→✅**.

### Design notes (grounded in a real Block region)

Passability lives in cell **tags**, not links; `ToMap` **discards** POI markers (so the factory captures POIs pre-`ToMap` and bridges Border→Block coords, baking them as serializable tags); per-cell room type flattens to `Environment`. See `design.md` "As-built freeze".

### Freeze

This is the freeze point — Phases 1–3 add capability *behind* the same surface without changing v1's calls. See `ROADMAP.md §3`.

### Verification

- `openspec validate maze-gen-mazzzze-phase0-contract --strict` — valid.
- `make ci` — lint + build + **334 tests** green. Façade coverage 100% (30 new tests incl. a reflection contract test that the public surface leaks no `Area`/`Cell`/`ExtensibleObject`/`Grid`).

### Companion PR

The first reference consumer, `mazzzze`, is rewired onto this façade in its own repo (branch `integrate-maze-gen-facade`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
