### PR TITLE
CI: prerelease-on-main channel + README badges

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,18 @@
 name: Publish to NuGet
 
-# Publishes PlayersWorlds.Maps to nuget.org on a version tag (vX.Y.Z).
-# Create the tag with `make release-minor` / `-patch` / `-major`.
+# Publishes PlayersWorlds.Maps to nuget.org:
+#   - a STABLE version on a vX.Y.Z tag   (cut with `make release-minor` etc.)
+#   - a PRERELEASE on every push to main (X.(Y+1).0-preview.<run>), so
+#     consumers can opt into the bleeding edge with `--prerelease`.
 #
-# Auth is NuGet Trusted Publishing (OIDC) — no stored API key. A trusted
-# publisher policy on nuget.org must be bound to THIS repo, the `publish.yml`
+# Auth is NuGet Trusted Publishing (OIDC) — no stored API key. The trusted
+# publisher policy on nuget.org is bound to THIS repo, the `publish.yml`
 # workflow, and the `production` environment; the account username is the
-# `NUGET_USER` repository variable.
+# `NUGET_USER` repository variable. Both paths reuse that one policy.
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 
@@ -22,21 +26,33 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need tags to compute the prerelease base version
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
 
-      - name: Derive and validate version from tag
-        # GITHUB_REF_NAME is the tag (vX.Y.Z). Validate it is real semver before
-        # it flows into build args (defense-in-depth against a malformed tag).
+      - name: Derive version
+        # Tag push -> the tag's version (validated). Main push -> a prerelease
+        # of the next minor above the latest stable tag, made monotonic by the
+        # run number: e.g. latest v0.1.0 -> 0.2.0-preview.<run>.
         run: |
-          version="${GITHUB_REF_NAME#v}"
-          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
-            echo "Tag '${GITHUB_REF_NAME}' is not a valid vX.Y.Z version." >&2
-            exit 1
+          if [ "${GITHUB_REF#refs/tags/}" != "$GITHUB_REF" ]; then
+            version="${GITHUB_REF_NAME#v}"
+            if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+              echo "Tag '${GITHUB_REF_NAME}' is not a valid vX.Y.Z version." >&2
+              exit 1
+            fi
+          else
+            git fetch --tags --force >/dev/null 2>&1 || true
+            latest="$(git tag --list 'v*' --sort=-v:refname | head -n1)"
+            latest="${latest:-v0.0.0}"
+            ver="${latest#v}"; major="${ver%%.*}"; rest="${ver#*.}"; minor="${rest%%.*}"
+            version="${major}.$((minor + 1)).0-preview.${GITHUB_RUN_NUMBER}"
           fi
+          echo "Publishing version $version"
           echo "VERSION=$version" >> "$GITHUB_ENV"
 
       - name: Restore

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # PlayersWorlds.Maps
 
+[![NuGet](https://img.shields.io/nuget/v/PlayersWorlds.Maps.svg?logo=nuget)](https://www.nuget.org/packages/PlayersWorlds.Maps/)
+[![NuGet prerelease](https://img.shields.io/nuget/vpre/PlayersWorlds.Maps.svg?label=nuget%20pre&color=orange)](https://www.nuget.org/packages/PlayersWorlds.Maps/absoluteLatest)
+[![Build](https://github.com/krmrn42/maze-gen/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/krmrn42/maze-gen/actions/workflows/main.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 A procedural **maze / dungeon map-generation** library — corridors, rooms, halls,
 caves, and impassable zones for 2D/3D games. It generates the *backbone* of a map;
 the consuming game supplies gameplay, loot, mobs, and the visual layer.

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -45,6 +45,16 @@ automatically and everyone else falls back to the package:
 Releases are cut with `make release-minor` (or `-patch`/`-major`), which tags
 `vX.Y.Z`; CI publishes that version to NuGet via OIDC trusted publishing.
 
+**Prerelease channel.** Every merge to `main` also publishes a prerelease
+(`X.(Y+1).0-preview.<n>`) so you can track the bleeding edge. Opt in with a
+floating prerelease version or `--prerelease`:
+
+```xml
+<PackageReference Include="PlayersWorlds.Maps" Version="0.2.0-preview.*" />
+```
+
+Stable restores never pick up a prerelease unless you ask for one.
+
 ## The contract in one breath
 
 A game codes against one narrow, frozen surface — the **region façade**


### PR DESCRIPTION
Two small follow-ups to the NuGet publishing setup.

## Prerelease channel
Every merge to `main` now publishes a prerelease to NuGet — `X.(Y+1).0-preview.<run>` (e.g. `0.2.0-preview.42`, the next minor above the latest stable tag, made monotonic by the run number). Stable releases stay tag-driven (`make release-*`).

Both paths live in the **same `publish.yml`** under the **same `production` environment**, so the existing OIDC trusted-publisher policy covers both — **no new NuGet or GitHub setup required**. The version-derivation step branches on the trigger; stable tags are still validated as semver.

Consumers opt in with a floating prerelease version or `--prerelease`; stable restores never pick a prerelease up:

```xml
<PackageReference Include="PlayersWorlds.Maps" Version="0.2.0-preview.*" />
```

## Badges
README gains NuGet version, NuGet prerelease, build status, and MIT license badges.

## Note on the `production` environment
For prereleases to publish automatically on merge, the `production` environment must **not** require manual approval. If you've added required reviewers there, every merge's prerelease will wait for a click — tell me and I'll split prereleases onto a separate ungated `preview` environment (which would need its own trusted-publisher policy).

Verified: version-derivation logic simulated for tag/main/no-tag cases; workflow YAML parses; `production` environment preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)