### PR TITLE
feat: tag wall orientation and split corners from wall-ends

### DIFF
--- a/src/Cell.cs
+++ b/src/Cell.cs
@@ -147,6 +147,18 @@ namespace PlayersWorlds.Maps {
             /// </summary>
             public static readonly CellTag MazeVoid =
                 new CellTag("MAZE2D_VOID");
+            /// <summary>
+            /// CellTag denoting a wall cell whose flat face runs along the
+            /// X axis (its wall continues east-west).
+            /// </summary>
+            public static readonly CellTag MazeWallAxisX =
+                new CellTag("MAZE2D_WALL_AXIS_X");
+            /// <summary>
+            /// CellTag denoting a wall cell whose flat face runs along the
+            /// Y axis (its wall continues north-south).
+            /// </summary>
+            public static readonly CellTag MazeWallAxisY =
+                new CellTag("MAZE2D_WALL_AXIS_Y");
         }
     }
 }

--- a/src/map_filters/Map2DClassifyWalls.cs
+++ b/src/map_filters/Map2DClassifyWalls.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlayersWorlds.Maps.MapFilters {
+
+    /// <summary>
+    /// A <see cref="Area" /> filter that classifies every wall cell by the
+    /// orientation of its flat face and distinguishes true corners from
+    /// straight walls, wall-ends and T-junctions.
+    /// </summary>
+    /// <remarks>
+    /// Run this as the LAST filter of the wall-build chain, after the
+    /// geometry (which cells are wall vs trail) is final. It reads each wall
+    /// cell's four orthogonal neighbours and tags it:
+    /// <list type="bullet">
+    /// <item>an opposite wall-neighbour pair (straight wall, or the flat run
+    /// of a T-junction — the perpendicular branch is ignored) →
+    /// <see cref="Cell.CellTag.MazeWallAxisX" /> / <c>MazeWallAxisY</c>;</item>
+    /// <item>exactly one wall-neighbour (a wall-end / T-junction offspring) →
+    /// the axis of that neighbour, so it textures as a wall continuing in that
+    /// direction rather than as a special end;</item>
+    /// <item>two perpendicular wall-neighbours with no through-line (a true
+    /// L-corner) → <see cref="Cell.CellTag.MazeWallCorner" />;</item>
+    /// <item>zero neighbours (island) or an enclosed cross/interior cell → no
+    /// orientation tag (no visible flat face).</item>
+    /// </list>
+    /// The coarse <c>MazeWallCorner</c> seeded mid-chain by
+    /// <see cref="Map2DSmoothCorners" /> (which cannot tell a corner from a
+    /// wall-end) is stripped first and re-applied only to true corners.
+    /// Out-of-bounds neighbours count as open.
+    /// </remarks>
+    public class Map2DClassifyWalls : Map2DFilter {
+
+        /// <summary>
+        /// Apply the filter to the specified <see cref="Area" />.
+        /// </summary>
+        /// <param name="map">The map to apply the filter to.</param>
+        override public void Render(Area map) {
+            var walls = new HashSet<Vector>(
+                map.Grid.Where(xy =>
+                    map[xy].Tags.Contains(Cell.CellTag.MazeWall) ||
+                    map[xy].Tags.Contains(Cell.CellTag.MazeWallCorner)));
+
+            bool IsWall(Vector xy) =>
+                map.Grid.Contains(xy) && walls.Contains(xy);
+
+            var assign = new Dictionary<Vector, Cell.CellTag>();
+            foreach (var xy in walls) {
+                var n = IsWall(xy + Vector.North2D);
+                var s = IsWall(xy + Vector.South2D);
+                var e = IsWall(xy + Vector.East2D);
+                var w = IsWall(xy + Vector.West2D);
+                var hasNS = n && s;
+                var hasEW = e && w;
+                var count = (n ? 1 : 0) + (s ? 1 : 0) + (e ? 1 : 0) + (w ? 1 : 0);
+
+                Cell.CellTag tag;
+                if (hasNS && hasEW) tag = null;
+                else if (hasNS) tag = Cell.CellTag.MazeWallAxisY;
+                else if (hasEW) tag = Cell.CellTag.MazeWallAxisX;
+                else if (count == 2) tag = Cell.CellTag.MazeWallCorner;
+                else if (count == 1)
+                    tag = (n || s) ? Cell.CellTag.MazeWallAxisY
+                                   : Cell.CellTag.MazeWallAxisX;
+                else tag = null;
+                assign[xy] = tag;
+            }
+
+            foreach (var xy in walls)
+                map[xy].Tags.Remove(Cell.CellTag.MazeWallCorner);
+            foreach (var kv in assign) {
+                if (kv.Value != null && !map[kv.Key].Tags.Contains(kv.Value))
+                    map[kv.Key].Tags.Add(kv.Value);
+            }
+        }
+    }
+}

--- a/src/maze/MazeAreaStyleConverter.cs
+++ b/src/maze/MazeAreaStyleConverter.cs
@@ -39,6 +39,7 @@ namespace PlayersWorlds.Maps.Maze {
                                             Cell.CellTag.MazeTrail,
                                             maxSpotWidth: 3,
                                             maxSpotHeight: 3))
+                .With(new Map2DClassifyWalls())
                 .Render(targetArea);
             return targetArea;
         }

--- a/src/renderers/Map2DStringRenderer.cs
+++ b/src/renderers/Map2DStringRenderer.cs
@@ -37,6 +37,8 @@ namespace PlayersWorlds.Maps.Renderers {
                     buffer[cellPosition.ToIndex(rootMap.Size)] =
                         map[cellPosition].Tags.Contains(Cell.CellTag.MazeVoid) ? ' ' :
                         map[cellPosition].Tags.Contains(Cell.CellTag.MazeWallCorner) ? '▒' :
+                        map[cellPosition].Tags.Contains(Cell.CellTag.MazeWallAxisX) ? '═' :
+                        map[cellPosition].Tags.Contains(Cell.CellTag.MazeWallAxisY) ? '║' :
                         map[cellPosition].Tags.Contains(Cell.CellTag.MazeWall) ? '▓' :
                         map[cellPosition].Tags.Contains(Cell.CellTag.MazeTrail) ? '░' :
                         '0';

--- a/tests/Map2DTest.cs
+++ b/tests/Map2DTest.cs
@@ -90,6 +90,8 @@ namespace PlayersWorlds.Maps {
         internal static Dictionary<char, Cell.CellTag> Tags = new Dictionary<char, Cell.CellTag>() {
             { '▓', Cell.CellTag.MazeWall },
             { '▒', Cell.CellTag.MazeWallCorner },
+            { '═', Cell.CellTag.MazeWallAxisX },
+            { '║', Cell.CellTag.MazeWallAxisY },
             { '░', Cell.CellTag.MazeTrail },
             { '0', Cell.CellTag.MazeVoid },
         };

--- a/tests/map_filters/Map2DClassifyWallsTest.cs
+++ b/tests/map_filters/Map2DClassifyWallsTest.cs
@@ -1,0 +1,83 @@
+using NUnit.Framework;
+using PlayersWorlds.Maps.Renderers;
+
+namespace PlayersWorlds.Maps.MapFilters {
+
+    [TestFixture]
+    internal class Map2DClassifyWallsTest : Test {
+
+        private static string Classify(string input) {
+            var map = Map2DTest.Parse(input, Map2DTest.Tags);
+            new Map2DClassifyWalls().Render(map);
+            return map.Render(new AsciiRendererFactory());
+        }
+
+        [Test]
+        public void HorizontalStraightGetsAxisX() {
+            var input =
+                "░░░░░\n" +
+                "░░░░░\n" +
+                "▓▓▓▓▓\n" +
+                "░░░░░\n" +
+                "░░░░░\n";
+            var expected =
+                "░░░░░\n" +
+                "░░░░░\n" +
+                "═════\n" +
+                "░░░░░\n" +
+                "░░░░░\n";
+            Assert.That(Classify(input), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void VerticalStraightGetsAxisY() {
+            var input =
+                "░░▓░░\n" +
+                "░░▓░░\n" +
+                "░░▓░░\n" +
+                "░░▓░░\n" +
+                "░░▓░░\n";
+            var expected =
+                "░░║░░\n" +
+                "░░║░░\n" +
+                "░░║░░\n" +
+                "░░║░░\n" +
+                "░░║░░\n";
+            Assert.That(Classify(input), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void TJunctionFlatWallKeepsThroughAxis_BranchGetsPerpendicularAxis() {
+            var input =
+                "░░░░░\n" +
+                "░░░░░\n" +
+                "▓▓▓▓▓\n" +
+                "░░▓░░\n" +
+                "░░▓░░\n";
+            var expected =
+                "░░░░░\n" +
+                "░░░░░\n" +
+                "═════\n" +
+                "░░║░░\n" +
+                "░░║░░\n";
+            Assert.That(Classify(input), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void TrueCornerGetsCornerTag() {
+            var input =
+                "░░░░░\n" +
+                "░░░░░\n" +
+                "░▓▓▓░\n" +
+                "░▓░░░\n" +
+                "░▓░░░\n";
+            var expected =
+                "░░░░░\n" +
+                "░░░░░\n" +
+                "░▒══░\n" +
+                "░║░░░\n" +
+                "░║░░░\n";
+            Assert.That(Classify(input), Is.EqualTo(expected));
+        }
+    }
+}


### PR DESCRIPTION
## What & why

Adds per-wall-cell **orientation classification** so consumers (the `mazzzze` Godot game) can orient wall geometry — e.g. run elongated rocks along a wall face — and tell **true corners** from wall-ends/junctions.

Previously `Map2DSmoothCorners` marked L-corners, wall-ends and islands identically as `MazeWallCorner` (it only tests trail-presence per axis).

## New

- `Cell.CellTag.MazeWallAxisX` / `MazeWallAxisY`.
- **`Map2DClassifyWalls`** — a final wall-build filter that reads each wall cell's 4 orthogonal neighbours (OOB = open) and tags:
  - opposite wall-neighbour pair (straight wall, or a T-junction's flat through-line — perpendicular branch ignored) → axis of that pair;
  - exactly one wall-neighbour (wall-end / T-junction offspring) → its axis, so it textures as a wall continuing that way;
  - two perpendicular neighbours (true L-corner) → `MazeWallCorner`;
  - island / enclosed cross → no orientation (no visible flat face).

  It strips the coarse `MazeWallCorner` seeded mid-chain and re-applies it only to true corners.
- Appended to the `MazeAreaStyleConverter` chain (runs last, on final geometry).
- `Map2DStringRenderer` glyphs `=` (AxisX) / `||` (AxisY) for ASCII verification.

Tags flow to consumers unchanged via `RegionView.CellAt → RegionCell.Tags`.

## Tests

4 new NUnit tests (horizontal/vertical straights, T-junction flat+branch, true corner). Fast suite green locally: **364 passed, 0 failed, 2 skipped**.

## Companion PR

This is the maze-gen half of a two-repo change. The consuming side is **vasiliy-kiryukhin/mazzzze#3** (environment kits — `WallAxis` / `MazeData.WallAxisAt` read these tags to orient wall rocks). Once this merges and publishes `PlayersWorlds.Maps`, mazzzze's package-based CI picks up the new tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)